### PR TITLE
Updated obsolete/deprecated calls

### DIFF
--- a/code/complete/GraphQL/Types/AttendeeType.cs
+++ b/code/complete/GraphQL/Types/AttendeeType.cs
@@ -16,9 +16,9 @@ namespace ConferencePlanner.GraphQL.Types
         protected override void Configure(IObjectTypeDescriptor<Attendee> descriptor)
         {
             descriptor
-                .AsNode()
+                .ImplementsNode()
                 .IdField(t => t.Id)
-                .NodeResolver((ctx, id) => ctx.DataLoader<AttendeeByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
+                .ResolveNode((ctx, id) => ctx.DataLoader<AttendeeByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
 
             descriptor
                 .Field(t => t.SessionsAttendees)

--- a/code/complete/GraphQL/Types/SessionType.cs
+++ b/code/complete/GraphQL/Types/SessionType.cs
@@ -17,9 +17,9 @@ namespace ConferencePlanner.GraphQL.Types
         protected override void Configure(IObjectTypeDescriptor<Session> descriptor)
         {
             descriptor
-                .AsNode()
+                .ImplementsNode()
                 .IdField(t => t.Id)
-                .NodeResolver((ctx, id) => ctx.DataLoader<SessionByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
+                .ResolveNode((ctx, id) => ctx.DataLoader<SessionByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
 
             descriptor
                 .Field(t => t.SessionSpeakers)

--- a/code/complete/GraphQL/Types/SpeakerType.cs
+++ b/code/complete/GraphQL/Types/SpeakerType.cs
@@ -16,9 +16,9 @@ namespace ConferencePlanner.GraphQL.Types
         protected override void Configure(IObjectTypeDescriptor<Speaker> descriptor)
         {
             descriptor
-                .AsNode()
+                .ImplementsNode()
                 .IdField(t => t.Id)
-                .NodeResolver((ctx, id) =>
+                .ResolveNode((ctx, id) =>
                     ctx.DataLoader<SpeakerByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
 
             descriptor

--- a/code/complete/GraphQL/Types/TrackType.cs
+++ b/code/complete/GraphQL/Types/TrackType.cs
@@ -16,10 +16,10 @@ namespace ConferencePlanner.GraphQL.Types
         protected override void Configure(IObjectTypeDescriptor<Track> descriptor)
         {
             descriptor
-                .AsNode()
+                .ImplementsNode()
                 .IdField(t => t.Id)
-                .NodeResolver((ctx, id) => ctx.DataLoader<TrackByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
-                    
+                .ResolveNode((ctx, id) => ctx.DataLoader<TrackByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
+
             descriptor
                 .Field(t => t.Sessions)
                 .ResolveWith<TrackResolvers>(t => t.GetSessionsAsync(default!, default!, default!, default))

--- a/code/session-4/GraphQL/Types/AttendeeType.cs
+++ b/code/session-4/GraphQL/Types/AttendeeType.cs
@@ -16,9 +16,9 @@ namespace ConferencePlanner.GraphQL.Types
         protected override void Configure(IObjectTypeDescriptor<Attendee> descriptor)
         {
             descriptor
-                .AsNode()
+                .ImplementsNode()
                 .IdField(t => t.Id)
-                .NodeResolver((ctx, id) => ctx.DataLoader<AttendeeByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
+                .ResolveNode((ctx, id) => ctx.DataLoader<AttendeeByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
 
             descriptor
                 .Field(t => t.SessionsAttendees)

--- a/code/session-4/GraphQL/Types/SessionType.cs
+++ b/code/session-4/GraphQL/Types/SessionType.cs
@@ -17,9 +17,9 @@ namespace ConferencePlanner.GraphQL.Types
         protected override void Configure(IObjectTypeDescriptor<Session> descriptor)
         {
             descriptor
-                .AsNode()
+                .ImplementsNode()
                 .IdField(t => t.Id)
-                .NodeResolver((ctx, id) => ctx.DataLoader<SessionByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
+                .ResolveNode((ctx, id) => ctx.DataLoader<SessionByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
 
             descriptor
                 .Field(t => t.SessionSpeakers)

--- a/code/session-4/GraphQL/Types/SpeakerType.cs
+++ b/code/session-4/GraphQL/Types/SpeakerType.cs
@@ -16,10 +16,10 @@ namespace ConferencePlanner.GraphQL.Types
         protected override void Configure(IObjectTypeDescriptor<Speaker> descriptor)
         {
             descriptor
-                   .AsNode()
+                   .ImplementsNode()
                    .IdField(t => t.Id)
-                   .NodeResolver((ctx, id) => ctx.DataLoader<SpeakerByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
-                       
+                   .ResolveNode((ctx, id) => ctx.DataLoader<SpeakerByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
+
             descriptor
                 .Field(t => t.SessionSpeakers)
                 .ResolveWith<SpeakerResolvers>(t => t.GetSessionsAsync(default!, default!, default!, default))

--- a/code/session-4/GraphQL/Types/TrackType.cs
+++ b/code/session-4/GraphQL/Types/TrackType.cs
@@ -16,11 +16,11 @@ namespace ConferencePlanner.GraphQL.Types
         protected override void Configure(IObjectTypeDescriptor<Track> descriptor)
         {
             descriptor
-                .AsNode()
+                .ImplementsNode()
                 .IdField(t => t.Id)
-                .NodeResolver((ctx, id) =>
+                .ResolveNode((ctx, id) =>
                     ctx.DataLoader<TrackByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
-                    
+
             descriptor
                 .Field(t => t.Sessions)
                 .ResolveWith<TrackResolvers>(t => t.GetSessionsAsync(default!, default!, default!, default))

--- a/code/session-5/GraphQL/Types/AttendeeType.cs
+++ b/code/session-5/GraphQL/Types/AttendeeType.cs
@@ -16,9 +16,9 @@ namespace ConferencePlanner.GraphQL.Types
         protected override void Configure(IObjectTypeDescriptor<Attendee> descriptor)
         {
             descriptor
-                .AsNode()
+                .ImplementsNode()
                 .IdField(t => t.Id)
-                .NodeResolver((ctx, id) => ctx.DataLoader<AttendeeByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
+                .ResolveNode((ctx, id) => ctx.DataLoader<AttendeeByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
 
             descriptor
                 .Field(t => t.SessionsAttendees)

--- a/code/session-5/GraphQL/Types/SessionType.cs
+++ b/code/session-5/GraphQL/Types/SessionType.cs
@@ -17,9 +17,9 @@ namespace ConferencePlanner.GraphQL.Types
         protected override void Configure(IObjectTypeDescriptor<Session> descriptor)
         {
             descriptor
-                .AsNode()
+                .ImplementsNode()
                 .IdField(t => t.Id)
-                .NodeResolver((ctx, id) => ctx.DataLoader<SessionByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
+                .ResolveNode((ctx, id) => ctx.DataLoader<SessionByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
 
             descriptor
                 .Field(t => t.SessionSpeakers)

--- a/code/session-5/GraphQL/Types/SpeakerType.cs
+++ b/code/session-5/GraphQL/Types/SpeakerType.cs
@@ -16,10 +16,10 @@ namespace ConferencePlanner.GraphQL.Types
         protected override void Configure(IObjectTypeDescriptor<Speaker> descriptor)
         {
             descriptor
-                   .AsNode()
+                   .ImplementsNode()
                    .IdField(t => t.Id)
-                   .NodeResolver((ctx, id) => ctx.DataLoader<SpeakerByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
-                       
+                   .ResolveNode((ctx, id) => ctx.DataLoader<SpeakerByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
+
             descriptor
                 .Field(t => t.SessionSpeakers)
                 .ResolveWith<SpeakerResolvers>(t => t.GetSessionsAsync(default!, default!, default!, default))

--- a/code/session-5/GraphQL/Types/TrackType.cs
+++ b/code/session-5/GraphQL/Types/TrackType.cs
@@ -16,11 +16,11 @@ namespace ConferencePlanner.GraphQL.Types
         protected override void Configure(IObjectTypeDescriptor<Track> descriptor)
         {
             descriptor
-                .AsNode()
+                .ImplementsNode()
                 .IdField(t => t.Id)
-                .NodeResolver((ctx, id) =>
+                .ResolveNode((ctx, id) =>
                     ctx.DataLoader<TrackByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
-                    
+
             descriptor
                 .Field(t => t.Sessions)
                 .ResolveWith<TrackResolvers>(t => t.GetSessionsAsync(default!, default!, default!, default))

--- a/code/session-6/GraphQL/Types/AttendeeType.cs
+++ b/code/session-6/GraphQL/Types/AttendeeType.cs
@@ -16,9 +16,9 @@ namespace ConferencePlanner.GraphQL.Types
         protected override void Configure(IObjectTypeDescriptor<Attendee> descriptor)
         {
             descriptor
-                .AsNode()
+                .ImplementsNode()
                 .IdField(t => t.Id)
-                .NodeResolver((ctx, id) => ctx.DataLoader<AttendeeByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
+                .ResolveNode((ctx, id) => ctx.DataLoader<AttendeeByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
 
             descriptor
                 .Field(t => t.SessionsAttendees)

--- a/code/session-6/GraphQL/Types/SessionType.cs
+++ b/code/session-6/GraphQL/Types/SessionType.cs
@@ -17,9 +17,9 @@ namespace ConferencePlanner.GraphQL.Types
         protected override void Configure(IObjectTypeDescriptor<Session> descriptor)
         {
             descriptor
-                .AsNode()
+                .ImplementsNode()
                 .IdField(t => t.Id)
-                .NodeResolver((ctx, id) => ctx.DataLoader<SessionByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
+                .ResolveNode((ctx, id) => ctx.DataLoader<SessionByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
 
             descriptor
                 .Field(t => t.SessionSpeakers)

--- a/code/session-6/GraphQL/Types/SpeakerType.cs
+++ b/code/session-6/GraphQL/Types/SpeakerType.cs
@@ -16,9 +16,9 @@ namespace ConferencePlanner.GraphQL.Types
         protected override void Configure(IObjectTypeDescriptor<Speaker> descriptor)
         {
             descriptor
-                   .AsNode()
+                   .ImplementsNode()
                    .IdField(t => t.Id)
-                   .NodeResolver((ctx, id) => ctx.DataLoader<SpeakerByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
+                   .ResolveNode((ctx, id) => ctx.DataLoader<SpeakerByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
                        
             descriptor
                 .Field(t => t.SessionSpeakers)

--- a/code/session-6/GraphQL/Types/TrackType.cs
+++ b/code/session-6/GraphQL/Types/TrackType.cs
@@ -16,9 +16,9 @@ namespace ConferencePlanner.GraphQL.Types
         protected override void Configure(IObjectTypeDescriptor<Track> descriptor)
         {
             descriptor
-                .AsNode()
+                .ImplementsNode()
                 .IdField(t => t.Id)
-                .NodeResolver((ctx, id) =>
+                .ResolveNode((ctx, id) =>
                     ctx.DataLoader<TrackByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
                     
             descriptor

--- a/code/session-7/GraphQL/Types/AttendeeType.cs
+++ b/code/session-7/GraphQL/Types/AttendeeType.cs
@@ -16,9 +16,9 @@ namespace ConferencePlanner.GraphQL.Types
         protected override void Configure(IObjectTypeDescriptor<Attendee> descriptor)
         {
             descriptor
-                .AsNode()
+                .ImplementsNode()
                 .IdField(t => t.Id)
-                .NodeResolver((ctx, id) => ctx.DataLoader<AttendeeByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
+                .ResolveNode((ctx, id) => ctx.DataLoader<AttendeeByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
 
             descriptor
                 .Field(t => t.SessionsAttendees)

--- a/code/session-7/GraphQL/Types/SessionType.cs
+++ b/code/session-7/GraphQL/Types/SessionType.cs
@@ -17,9 +17,9 @@ namespace ConferencePlanner.GraphQL.Types
         protected override void Configure(IObjectTypeDescriptor<Session> descriptor)
         {
             descriptor
-                .AsNode()
+                .ImplementsNode()
                 .IdField(t => t.Id)
-                .NodeResolver((ctx, id) => ctx.DataLoader<SessionByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
+                .ResolveNode((ctx, id) => ctx.DataLoader<SessionByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
 
             descriptor
                 .Field(t => t.SessionSpeakers)

--- a/code/session-7/GraphQL/Types/SpeakerType.cs
+++ b/code/session-7/GraphQL/Types/SpeakerType.cs
@@ -16,9 +16,9 @@ namespace ConferencePlanner.GraphQL.Types
         protected override void Configure(IObjectTypeDescriptor<Speaker> descriptor)
         {
             descriptor
-                   .AsNode()
+                   .ImplementsNode()
                    .IdField(t => t.Id)
-                   .NodeResolver((ctx, id) => ctx.DataLoader<SpeakerByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
+                   .ResolveNode((ctx, id) => ctx.DataLoader<SpeakerByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
                        
             descriptor
                 .Field(t => t.SessionSpeakers)

--- a/code/session-7/GraphQL/Types/TrackType.cs
+++ b/code/session-7/GraphQL/Types/TrackType.cs
@@ -16,9 +16,9 @@ namespace ConferencePlanner.GraphQL.Types
         protected override void Configure(IObjectTypeDescriptor<Track> descriptor)
         {
             descriptor
-                .AsNode()
+                .ImplementsNode()
                 .IdField(t => t.Id)
-                .NodeResolver((ctx, id) =>
+                .ResolveNode((ctx, id) =>
                     ctx.DataLoader<TrackByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
                     
             descriptor

--- a/code/session-8/GraphQL/Types/AttendeeType.cs
+++ b/code/session-8/GraphQL/Types/AttendeeType.cs
@@ -16,9 +16,9 @@ namespace ConferencePlanner.GraphQL.Types
         protected override void Configure(IObjectTypeDescriptor<Attendee> descriptor)
         {
             descriptor
-                .AsNode()
+                .ImplementsNode()
                 .IdField(t => t.Id)
-                .NodeResolver((ctx, id) => ctx.DataLoader<AttendeeByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
+                .ResolveNode((ctx, id) => ctx.DataLoader<AttendeeByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
 
             descriptor
                 .Field(t => t.SessionsAttendees)

--- a/code/session-8/GraphQL/Types/SessionType.cs
+++ b/code/session-8/GraphQL/Types/SessionType.cs
@@ -17,9 +17,9 @@ namespace ConferencePlanner.GraphQL.Types
         protected override void Configure(IObjectTypeDescriptor<Session> descriptor)
         {
             descriptor
-                .AsNode()
+                .ImplementsNode()
                 .IdField(t => t.Id)
-                .NodeResolver((ctx, id) => ctx.DataLoader<SessionByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
+                .ResolveNode((ctx, id) => ctx.DataLoader<SessionByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
 
             descriptor
                 .Field(t => t.SessionSpeakers)

--- a/code/session-8/GraphQL/Types/SpeakerType.cs
+++ b/code/session-8/GraphQL/Types/SpeakerType.cs
@@ -16,9 +16,9 @@ namespace ConferencePlanner.GraphQL.Types
         protected override void Configure(IObjectTypeDescriptor<Speaker> descriptor)
         {
             descriptor
-                   .AsNode()
+                   .ImplementsNode()
                    .IdField(t => t.Id)
-                   .NodeResolver((ctx, id) => ctx.DataLoader<SpeakerByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
+                   .ResolveNode((ctx, id) => ctx.DataLoader<SpeakerByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
                        
             descriptor
                 .Field(t => t.SessionSpeakers)

--- a/code/session-8/GraphQL/Types/TrackType.cs
+++ b/code/session-8/GraphQL/Types/TrackType.cs
@@ -16,9 +16,9 @@ namespace ConferencePlanner.GraphQL.Types
         protected override void Configure(IObjectTypeDescriptor<Track> descriptor)
         {
             descriptor
-                .AsNode()
+                .ImplementsNode()
                 .IdField(t => t.Id)
-                .NodeResolver((ctx, id) =>
+                .ResolveNode((ctx, id) =>
                     ctx.DataLoader<TrackByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
                     
             descriptor

--- a/docs/4-schema-design.md
+++ b/docs/4-schema-design.md
@@ -217,9 +217,9 @@ Now that we have reorganized our mutations, we will refactor the schema to a pro
             protected override void Configure(IObjectTypeDescriptor<Speaker> descriptor)
             {
                 descriptor
-                    .AsNode()
+                    .ImplementsNode()
                     .IdField(t => t.Id)
-                    .NodeResolver((ctx, id) => ctx.DataLoader<SpeakerByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
+                    .ResolveNode((ctx, id) => ctx.DataLoader<SpeakerByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
                         
                 descriptor
                     .Field(t => t.SessionSpeakers)
@@ -249,13 +249,13 @@ Now that we have reorganized our mutations, we will refactor the schema to a pro
     }
    ```
 
-   > The following piece of code marked our `SpeakerType` as implementing the `Node` interface. It also defined that the `id` field that the node interface specifies is implement by the `Id` on our entity. The internal `Id` is consequently rewritten to a global object identifier that contains the internal id plus the type name. Last but not least we defined a `NodeResolver` that is able to load the entity by `id`.
+   > The following piece of code marked our `SpeakerType` as implementing the `Node` interface. It also defined that the `id` field that the node interface specifies is implement by the `Id` on our entity. The internal `Id` is consequently rewritten to a global object identifier that contains the internal id plus the type name. Last but not least we defined a `ResolveNode` that is able to load the entity by `id`.
 
    > ```csharp
    > descriptor
-   >     .AsNode()
+   >     .ImplementsNode()
    >     .IdField(t => t.Id)
-   >    .NodeResolver((ctx, id) => ctx.DataLoader<SpeakerByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
+   >    .ResolveNode((ctx, id) => ctx.DataLoader<SpeakerByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
    > ```
 
 1. Head over to the `Query.cs` and annotate the `id` argument of `GetSpeaker` with the `ID` attribute.
@@ -401,9 +401,9 @@ We will start by adding the rest of the DataLoader that we will need. Then we wi
             protected override void Configure(IObjectTypeDescriptor<Attendee> descriptor)
             {
                 descriptor
-                    .AsNode()
+                    .ImplementsNode()
                     .IdField(t => t.Id)
-                    .NodeResolver((ctx, id) => ctx.DataLoader<AttendeeByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
+                    .ResolveNode((ctx, id) => ctx.DataLoader<AttendeeByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
 
                 descriptor
                     .Field(t => t.SessionsAttendees)
@@ -454,9 +454,9 @@ We will start by adding the rest of the DataLoader that we will need. Then we wi
             protected override void Configure(IObjectTypeDescriptor<Session> descriptor)
             {
                 descriptor
-                    .AsNode()
+                    .ImplementsNode()
                     .IdField(t => t.Id)
-                    .NodeResolver((ctx, id) => ctx.DataLoader<SessionByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
+                    .ResolveNode((ctx, id) => ctx.DataLoader<SessionByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
 
                 descriptor
                     .Field(t => t.SessionSpeakers)
@@ -549,9 +549,9 @@ We will start by adding the rest of the DataLoader that we will need. Then we wi
             protected override void Configure(IObjectTypeDescriptor<Track> descriptor)
             {
                 descriptor
-                    .AsNode()
+                    .ImplementsNode()
                     .IdField(t => t.Id)
-                    .NodeResolver((ctx, id) =>
+                    .ResolveNode((ctx, id) =>
                         ctx.DataLoader<TrackByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
                         
                 descriptor


### PR DESCRIPTION
Updated all code and docs.
1. `AsNode() -> ImplementsNode()`
2. `NodeResolver(NodeResolverDeletage<T,U>) => ResolveNode(NodeResolverDeletage<T,U>)`