### PR TITLE
Fix TrackQueries method naming GetSessionsByIdAsync to GetTracksByIdAsync

### DIFF
--- a/code/session-4/GraphQL/Tracks/TrackQueries.cs
+++ b/code/session-4/GraphQL/Tracks/TrackQueries.cs
@@ -40,7 +40,7 @@ namespace ConferencePlanner.GraphQL.Tracks
             CancellationToken cancellationToken) =>
             trackById.LoadAsync(id, cancellationToken);
 
-        public async Task<IEnumerable<Track>> GetSessionsByIdAsync(
+        public async Task<IEnumerable<Track>> GetTracksByIdAsync(
             [ID(nameof(Track))] int[] ids,
             TrackByIdDataLoader trackById,
             CancellationToken cancellationToken) =>

--- a/code/session-5/GraphQL/Tracks/TrackQueries.cs
+++ b/code/session-5/GraphQL/Tracks/TrackQueries.cs
@@ -40,7 +40,7 @@ namespace ConferencePlanner.GraphQL.Tracks
             CancellationToken cancellationToken) =>
             trackById.LoadAsync(id, cancellationToken);
 
-        public async Task<IEnumerable<Track>> GetSessionsByIdAsync(
+        public async Task<IEnumerable<Track>> GetTracksByIdAsync(
             [ID(nameof(Track))] int[] ids,
             TrackByIdDataLoader trackById,
             CancellationToken cancellationToken) =>

--- a/code/session-6/GraphQL/Tracks/TrackQueries.cs
+++ b/code/session-6/GraphQL/Tracks/TrackQueries.cs
@@ -40,7 +40,7 @@ namespace ConferencePlanner.GraphQL.Tracks
             CancellationToken cancellationToken) =>
             trackById.LoadAsync(id, cancellationToken);
 
-        public async Task<IEnumerable<Track>> GetSessionsByIdAsync(
+        public async Task<IEnumerable<Track>> GetTracksByIdAsync(
             [ID(nameof(Track))] int[] ids,
             TrackByIdDataLoader trackById,
             CancellationToken cancellationToken) =>

--- a/code/session-7/GraphQL/Tracks/TrackQueries.cs
+++ b/code/session-7/GraphQL/Tracks/TrackQueries.cs
@@ -40,7 +40,7 @@ namespace ConferencePlanner.GraphQL.Tracks
             CancellationToken cancellationToken) =>
             trackById.LoadAsync(id, cancellationToken);
 
-        public async Task<IEnumerable<Track>> GetSessionsByIdAsync(
+        public async Task<IEnumerable<Track>> GetTracksByIdAsync(
             [ID(nameof(Track))] int[] ids,
             TrackByIdDataLoader trackById,
             CancellationToken cancellationToken) =>

--- a/code/session-8/GraphQL/Tracks/TrackQueries.cs
+++ b/code/session-8/GraphQL/Tracks/TrackQueries.cs
@@ -40,7 +40,7 @@ namespace ConferencePlanner.GraphQL.Tracks
             CancellationToken cancellationToken) =>
             trackById.LoadAsync(id, cancellationToken);
 
-        public async Task<IEnumerable<Track>> GetSessionsByIdAsync(
+        public async Task<IEnumerable<Track>> GetTracksByIdAsync(
             [ID(nameof(Track))] int[] ids,
             TrackByIdDataLoader trackById,
             CancellationToken cancellationToken) =>

--- a/docs/4-schema-design.md
+++ b/docs/4-schema-design.md
@@ -1308,7 +1308,7 @@ In this section, we will optimize our `Query` type by bringing in more fields to
    }
    ```
 
-1. Again, head over to the `Startup.cs` and register the `SessionQueries` with the schema builder.
+1. Again, head over to the `Startup.cs` and register the `TrackQueries` with the schema builder.
 
    ```csharp
    services


### PR DESCRIPTION
Issue #19 

Seems like TrackQueries.GetSessionsByIdAsync should be GetTracksByIdAsync. Issue found in sessions 4-8

Also docs for session 4 in "Offer plural versions fields and be precise about field names" step 6 after adding the track queries says
"6. Again, head over to the Startup.cs and register the SessionQueries with the schema builder." 
when it was already added in step 4
"4. Register the SessionQueries with the schema builder which is located in the Startup.cs"
and likely should've been
"6. Again, head over to the Startup.cs and register the **TrackQueries** with the schema builder."