### PR TITLE
Fix typos

### DIFF
--- a/docs/5-understanding-middleware.md
+++ b/docs/5-understanding-middleware.md
@@ -43,7 +43,7 @@ descriptor.Use(next => async context =>
 
 The above middleware first invokes the `next` middleware, and by doing so, gives up control and lets the rest of the pipeline do its job.
 
-After `next` has finished executing, the middleware checks if the result is a `string`, and if so, it applies a `ToUpperInvariant` on that `string` and writes back the updated `string` to `context.Result``.
+After `next` has finished executing, the middleware checks if the result is a `string`, and if so, it applies a `ToUpperInvariant` on that `string` and writes back the updated `string` to `context.Result`.
 
 ![Middleware Flow with ToUpper Middleware and Resolver](images/19-middleware-flow.png)
 

--- a/docs/6-adding-complex-filter-capabilities.md
+++ b/docs/6-adding-complex-filter-capabilities.md
@@ -18,7 +18,7 @@ Let us start by implementing the last Relay server specification we are still mi
        context.Tracks.OrderBy(t => t.Name);
    ```
 
-   > The new resolver will instead of executing the database query return an ` IQueryable``. The `IQueryable`is like a query builder. By applying the`UsePaging` middleware, we are rewriting the database query to only fetch the items that we need for our data-set.
+   > The new resolver will instead of executing the database query return an `IQueryable`. The `IQueryable` is like a query builder. By applying the `UsePaging` middleware, we are rewriting the database query to only fetch the items that we need for our data-set.
 
    The resolver pipeline for our field now looks like the following:
 


### PR DESCRIPTION
Some have bigger effects than it seemed.

Before:
> The new resolver will instead of executing the database query return an ` IQueryable``. The `IQueryable`is like a query builder. By applying the`UsePaging` middleware, we are rewriting the database query to only fetch the items that we need for our data-set.

After:
> The new resolver will instead of executing the database query return an `IQueryable`. The `IQueryable` is like a query builder. By applying the `UsePaging` middleware, we are rewriting the database query to only fetch the items that we need for our data-set.
