### PR TITLE
Change all type-classes to use the UseDbContext middleware for access…

### DIFF
--- a/code/session-4/GraphQL/Types/AttendeeType.cs
+++ b/code/session-4/GraphQL/Types/AttendeeType.cs
@@ -23,6 +23,7 @@ namespace ConferencePlanner.GraphQL.Types
             descriptor
                 .Field(t => t.SessionsAttendees)
                 .ResolveWith<AttendeeResolvers>(t => t.GetSessionsAsync(default!, default!, default!, default))
+                .UseDbContext<ApplicationDbContext>()
                 .Name("sessions");
         }
 

--- a/code/session-4/GraphQL/Types/SessionType.cs
+++ b/code/session-4/GraphQL/Types/SessionType.cs
@@ -24,11 +24,13 @@ namespace ConferencePlanner.GraphQL.Types
             descriptor
                 .Field(t => t.SessionSpeakers)
                 .ResolveWith<SessionResolvers>(t => t.GetSpeakersAsync(default!, default!, default!, default))
+                .UseDbContext<ApplicationDbContext>()
                 .Name("speakers");
 
             descriptor
                 .Field(t => t.SessionAttendees)
                 .ResolveWith<SessionResolvers>(t => t.GetAttendeesAsync(default!, default!, default!, default))
+                .UseDbContext<ApplicationDbContext>()
                 .Name("attendees");
 
             descriptor
@@ -42,7 +44,6 @@ namespace ConferencePlanner.GraphQL.Types
 
         private class SessionResolvers
         {
-            [UseApplicationDbContext]
             public async Task<IEnumerable<Speaker>> GetSpeakersAsync(
                 Session session,
                 [ScopedService] ApplicationDbContext dbContext,
@@ -58,7 +59,6 @@ namespace ConferencePlanner.GraphQL.Types
                 return await speakerById.LoadAsync(speakerIds, cancellationToken);
             }
 
-            [UseApplicationDbContext]
             public async Task<IEnumerable<Attendee>> GetAttendeesAsync(
                 Session session,
                 [ScopedService] ApplicationDbContext dbContext,

--- a/code/session-4/GraphQL/Types/TrackType.cs
+++ b/code/session-4/GraphQL/Types/TrackType.cs
@@ -24,6 +24,7 @@ namespace ConferencePlanner.GraphQL.Types
             descriptor
                 .Field(t => t.Sessions)
                 .ResolveWith<TrackResolvers>(t => t.GetSessionsAsync(default!, default!, default!, default))
+                .UseDbContext<ApplicationDbContext>()
                 .UsePaging<NonNullType<SessionType>>()
                 .Name("sessions");
         }

--- a/code/session-5/GraphQL/Types/AttendeeType.cs
+++ b/code/session-5/GraphQL/Types/AttendeeType.cs
@@ -23,6 +23,7 @@ namespace ConferencePlanner.GraphQL.Types
             descriptor
                 .Field(t => t.SessionsAttendees)
                 .ResolveWith<AttendeeResolvers>(t => t.GetSessionsAsync(default!, default!, default!, default))
+                .UseDbContext<ApplicationDbContext>()
                 .Name("sessions");
         }
 

--- a/code/session-5/GraphQL/Types/SessionType.cs
+++ b/code/session-5/GraphQL/Types/SessionType.cs
@@ -24,11 +24,13 @@ namespace ConferencePlanner.GraphQL.Types
             descriptor
                 .Field(t => t.SessionSpeakers)
                 .ResolveWith<SessionResolvers>(t => t.GetSpeakersAsync(default!, default!, default!, default))
+                .UseDbContext<ApplicationDbContext>()
                 .Name("speakers");
 
             descriptor
                 .Field(t => t.SessionAttendees)
                 .ResolveWith<SessionResolvers>(t => t.GetAttendeesAsync(default!, default!, default!, default))
+                .UseDbContext<ApplicationDbContext>()
                 .Name("attendees");
 
             descriptor
@@ -42,7 +44,6 @@ namespace ConferencePlanner.GraphQL.Types
 
         private class SessionResolvers
         {
-            [UseApplicationDbContext]
             public async Task<IEnumerable<Speaker>> GetSpeakersAsync(
                 Session session,
                 [ScopedService] ApplicationDbContext dbContext,
@@ -58,7 +59,6 @@ namespace ConferencePlanner.GraphQL.Types
                 return await speakerById.LoadAsync(speakerIds, cancellationToken);
             }
 
-            [UseApplicationDbContext]
             public async Task<IEnumerable<Attendee>> GetAttendeesAsync(
                 Session session,
                 [ScopedService] ApplicationDbContext dbContext,

--- a/code/session-5/GraphQL/Types/TrackType.cs
+++ b/code/session-5/GraphQL/Types/TrackType.cs
@@ -24,6 +24,7 @@ namespace ConferencePlanner.GraphQL.Types
             descriptor
                 .Field(t => t.Sessions)
                 .ResolveWith<TrackResolvers>(t => t.GetSessionsAsync(default!, default!, default!, default))
+                .UseDbContext<ApplicationDbContext>()
                 .UsePaging<NonNullType<SessionType>>()
                 .Name("sessions");
 

--- a/code/session-6/GraphQL/Types/AttendeeType.cs
+++ b/code/session-6/GraphQL/Types/AttendeeType.cs
@@ -23,6 +23,7 @@ namespace ConferencePlanner.GraphQL.Types
             descriptor
                 .Field(t => t.SessionsAttendees)
                 .ResolveWith<AttendeeResolvers>(t => t.GetSessionsAsync(default!, default!, default!, default))
+                .UseDbContext<ApplicationDbContext>()
                 .Name("sessions");
         }
 

--- a/code/session-6/GraphQL/Types/SessionType.cs
+++ b/code/session-6/GraphQL/Types/SessionType.cs
@@ -24,11 +24,13 @@ namespace ConferencePlanner.GraphQL.Types
             descriptor
                 .Field(t => t.SessionSpeakers)
                 .ResolveWith<SessionResolvers>(t => t.GetSpeakersAsync(default!, default!, default!, default))
+                .UseDbContext<ApplicationDbContext>()
                 .Name("speakers");
 
             descriptor
                 .Field(t => t.SessionAttendees)
                 .ResolveWith<SessionResolvers>(t => t.GetAttendeesAsync(default!, default!, default!, default))
+                .UseDbContext<ApplicationDbContext>()
                 .Name("attendees");
 
             descriptor
@@ -42,7 +44,6 @@ namespace ConferencePlanner.GraphQL.Types
 
         private class SessionResolvers
         {
-            [UseApplicationDbContext]
             public async Task<IEnumerable<Speaker>> GetSpeakersAsync(
                 Session session,
                 [ScopedService] ApplicationDbContext dbContext,
@@ -58,7 +59,6 @@ namespace ConferencePlanner.GraphQL.Types
                 return await speakerById.LoadAsync(speakerIds, cancellationToken);
             }
 
-            [UseApplicationDbContext]
             public async Task<IEnumerable<Attendee>> GetAttendeesAsync(
                 Session session,
                 [ScopedService] ApplicationDbContext dbContext,

--- a/code/session-6/GraphQL/Types/TrackType.cs
+++ b/code/session-6/GraphQL/Types/TrackType.cs
@@ -24,6 +24,7 @@ namespace ConferencePlanner.GraphQL.Types
             descriptor
                 .Field(t => t.Sessions)
                 .ResolveWith<TrackResolvers>(t => t.GetSessionsAsync(default!, default!, default!, default))
+                .UseDbContext<ApplicationDbContext>()
                 .UsePaging<NonNullType<SessionType>>()
                 .Name("sessions");
 

--- a/code/session-7/GraphQL/Types/AttendeeType.cs
+++ b/code/session-7/GraphQL/Types/AttendeeType.cs
@@ -23,6 +23,7 @@ namespace ConferencePlanner.GraphQL.Types
             descriptor
                 .Field(t => t.SessionsAttendees)
                 .ResolveWith<AttendeeResolvers>(t => t.GetSessionsAsync(default!, default!, default!, default))
+                .UseDbContext<ApplicationDbContext>()
                 .Name("sessions");
         }
 

--- a/code/session-7/GraphQL/Types/SessionType.cs
+++ b/code/session-7/GraphQL/Types/SessionType.cs
@@ -24,11 +24,13 @@ namespace ConferencePlanner.GraphQL.Types
             descriptor
                 .Field(t => t.SessionSpeakers)
                 .ResolveWith<SessionResolvers>(t => t.GetSpeakersAsync(default!, default!, default!, default))
+                .UseDbContext<ApplicationDbContext>()
                 .Name("speakers");
 
             descriptor
                 .Field(t => t.SessionAttendees)
                 .ResolveWith<SessionResolvers>(t => t.GetAttendeesAsync(default!, default!, default!, default))
+                .UseDbContext<ApplicationDbContext>()
                 .Name("attendees");
 
             descriptor
@@ -42,7 +44,6 @@ namespace ConferencePlanner.GraphQL.Types
 
         private class SessionResolvers
         {
-            [UseApplicationDbContext]
             public async Task<IEnumerable<Speaker>> GetSpeakersAsync(
                 Session session,
                 [ScopedService] ApplicationDbContext dbContext,
@@ -58,7 +59,6 @@ namespace ConferencePlanner.GraphQL.Types
                 return await speakerById.LoadAsync(speakerIds, cancellationToken);
             }
 
-            [UseApplicationDbContext]
             public async Task<IEnumerable<Attendee>> GetAttendeesAsync(
                 Session session,
                 [ScopedService] ApplicationDbContext dbContext,

--- a/code/session-7/GraphQL/Types/TrackType.cs
+++ b/code/session-7/GraphQL/Types/TrackType.cs
@@ -24,6 +24,7 @@ namespace ConferencePlanner.GraphQL.Types
             descriptor
                 .Field(t => t.Sessions)
                 .ResolveWith<TrackResolvers>(t => t.GetSessionsAsync(default!, default!, default!, default))
+                .UseDbContext<ApplicationDbContext>()
                 .UsePaging<NonNullType<SessionType>>()
                 .Name("sessions");
 

--- a/code/session-8/GraphQL/Types/AttendeeType.cs
+++ b/code/session-8/GraphQL/Types/AttendeeType.cs
@@ -23,6 +23,7 @@ namespace ConferencePlanner.GraphQL.Types
             descriptor
                 .Field(t => t.SessionsAttendees)
                 .ResolveWith<AttendeeResolvers>(t => t.GetSessionsAsync(default!, default!, default!, default))
+                .UseDbContext<ApplicationDbContext>()
                 .Name("sessions");
         }
 

--- a/code/session-8/GraphQL/Types/SessionType.cs
+++ b/code/session-8/GraphQL/Types/SessionType.cs
@@ -24,11 +24,13 @@ namespace ConferencePlanner.GraphQL.Types
             descriptor
                 .Field(t => t.SessionSpeakers)
                 .ResolveWith<SessionResolvers>(t => t.GetSpeakersAsync(default!, default!, default!, default))
+                .UseDbContext<ApplicationDbContext>()
                 .Name("speakers");
 
             descriptor
                 .Field(t => t.SessionAttendees)
                 .ResolveWith<SessionResolvers>(t => t.GetAttendeesAsync(default!, default!, default!, default))
+                .UseDbContext<ApplicationDbContext>()
                 .Name("attendees");
 
             descriptor
@@ -42,7 +44,6 @@ namespace ConferencePlanner.GraphQL.Types
 
         private class SessionResolvers
         {
-            [UseApplicationDbContext]
             public async Task<IEnumerable<Speaker>> GetSpeakersAsync(
                 Session session,
                 [ScopedService] ApplicationDbContext dbContext,
@@ -58,7 +59,6 @@ namespace ConferencePlanner.GraphQL.Types
                 return await speakerById.LoadAsync(speakerIds, cancellationToken);
             }
 
-            [UseApplicationDbContext]
             public async Task<IEnumerable<Attendee>> GetAttendeesAsync(
                 Session session,
                 [ScopedService] ApplicationDbContext dbContext,

--- a/code/session-8/GraphQL/Types/TrackType.cs
+++ b/code/session-8/GraphQL/Types/TrackType.cs
@@ -24,6 +24,7 @@ namespace ConferencePlanner.GraphQL.Types
             descriptor
                 .Field(t => t.Sessions)
                 .ResolveWith<TrackResolvers>(t => t.GetSessionsAsync(default!, default!, default!, default))
+                .UseDbContext<ApplicationDbContext>()
                 .UsePaging<NonNullType<SessionType>>()
                 .Name("sessions");
 

--- a/docs/4-schema-design.md
+++ b/docs/4-schema-design.md
@@ -408,6 +408,7 @@ We will start by adding the rest of the DataLoader that we will need. Then we wi
                 descriptor
                     .Field(t => t.SessionsAttendees)
                     .ResolveWith<AttendeeResolvers>(t => t.GetSessionsAsync(default!, default!, default!, default))
+                    .UseDbContext<ApplicationDbContext>()
                     .Name("sessions");
             }
 
@@ -461,11 +462,13 @@ We will start by adding the rest of the DataLoader that we will need. Then we wi
                 descriptor
                     .Field(t => t.SessionSpeakers)
                     .ResolveWith<SessionResolvers>(t => t.GetSpeakersAsync(default!, default!, default!, default))
+                    .UseDbContext<ApplicationDbContext>()
                     .Name("speakers");
 
                 descriptor
                     .Field(t => t.SessionAttendees)
                     .ResolveWith<SessionResolvers>(t => t.GetAttendeesAsync(default!, default!, default!, default))
+                    .UseDbContext<ApplicationDbContext>()
                     .Name("attendees");
 
                 descriptor
@@ -479,7 +482,6 @@ We will start by adding the rest of the DataLoader that we will need. Then we wi
 
             private class SessionResolvers
             {
-                [UseApplicationDbContext]
                 public async Task<IEnumerable<Speaker>> GetSpeakersAsync(
                     Session session,
                     [ScopedService] ApplicationDbContext dbContext,
@@ -495,7 +497,6 @@ We will start by adding the rest of the DataLoader that we will need. Then we wi
                     return await speakerById.LoadAsync(speakerIds, cancellationToken);
                 }
 
-                [UseApplicationDbContext]
                 public async Task<IEnumerable<Attendee>> GetAttendeesAsync(
                     Session session,
                     [ScopedService] ApplicationDbContext dbContext,
@@ -557,6 +558,7 @@ We will start by adding the rest of the DataLoader that we will need. Then we wi
                 descriptor
                     .Field(t => t.Sessions)
                     .ResolveWith<TrackResolvers>(t => t.GetSessionsAsync(default!, default!, default!, default))
+                    .UseDbContext<ApplicationDbContext>()
                     .Name("sessions");
             }
 

--- a/docs/6-adding-complex-filter-capabilities.md
+++ b/docs/6-adding-complex-filter-capabilities.md
@@ -126,6 +126,7 @@ Let us start by implementing the last Relay server specification we are still mi
    descriptor
        .Field(t => t.Sessions)
        .ResolveWith<TrackResolvers>(t => t.GetSessionsAsync(default!, default!, default))
+       .UseDbContext<ApplicationDbContext>()
        .UsePaging<NonNullType<SessionType>>()
        .Name("sessions");
    ```


### PR DESCRIPTION
Requested to create PR in https://github.com/ChilliCream/graphql-workshop/issues/23.

The change makes all the type-classes use the UseDbContext middleware to access the database. This is how the code looks like in the complete source tree.