### PR TITLE
Fix typo error in 4-schema-design.md

### DIFF
--- a/docs/4-schema-design.md
+++ b/docs/4-schema-design.md
@@ -18,7 +18,7 @@ First, we will restructure our GraphQL server so that it will better scale once 
    mkdir GraphQL/Common
    ```
 
-1. Create a field `PayloadBase.cs` in the `Common` directory with the following code:
+1. Create a class `Payload.cs` in the `Common` directory with the following code:
 
    ```csharp
     using System.Collections.Generic;


### PR DESCRIPTION
- Description is mentioning a 'field' instead of a 'class'.
- The class name is not equal to the example code.