### PR TITLE
Update 3-understanding-dataLoader.md

### DIFF
--- a/docs/3-understanding-dataLoader.md
+++ b/docs/3-understanding-dataLoader.md
@@ -305,7 +305,7 @@ In order to expand our GraphQL server model further we've got several more data 
    }
    ```
 
-1. Create a `SessionSpeaker` class with the following code:
+1. Create a `SessionSpeaker.cs` class with the following code:
 
    ```csharp
    namespace ConferencePlanner.GraphQL.Data


### PR DESCRIPTION
Match convention used by adding .cs to the end of the intended class name "SessionSpeaker"