### PR TITLE
Update 1-creating-a-graphql-server-project

### DIFF
--- a/docs/1-creating-a-graphql-server-project.md
+++ b/docs/1-creating-a-graphql-server-project.md
@@ -31,8 +31,9 @@
     }
     ```
 
-1. Add a reference to the NuGet package package `Microsoft.EntityFrameworkCore.Sqlite` version `5.0.0`.
+1. Add a reference to the NuGet package package `Microsoft.EntityFrameworkCore.Sqlite` version `5.0.0` and also Microsoft.EntityFrameworkCore.Sqlite.Design.
    1. `dotnet add GraphQL package Microsoft.EntityFrameworkCore.Sqlite --version 5.0.0`
+   2. ` dotnet add GraphQL package  Microsoft.EntityFrameworkCore.Sqlite.Design`
 1. Next we'll create a new Entity Framework DbContext. Create a new `ApplicationDbContext` class in the `Data` folder using the following code:
 
     ```csharp
@@ -57,7 +58,6 @@
 1. Add the following code to the top of the `ConfigureServices()` method in `Startup.cs`:
 
     ```csharp
-    services.AddDbContext<ApplicationDbContext>(options => options.UseSqlite("Data Source=conferences.db"));
     ```
 
     > This code registers the `ApplicationDbContext` service so it can be injected into resolvers.


### PR DESCRIPTION
It is missing the following command
`dotnet add GraphQL package  Microsoft.EntityFrameworkCore.Sqlite.Design`
The following error will show without it the above reference:
`'DbContextOptionsBuilder' does not contain a definition for 'UseSqlite' and no accessible extension method 'UseSqlite' accepting a first argument of type 'DbContextOptionsBuilder' could be found (are you missing a using directive or an assembly reference?)`