### PR TITLE
Fix mismatched curly brackets in 3-schema-design.md SessionDataLoader…

### DIFF
--- a/docs/3-schema-design.md
+++ b/docs/3-schema-design.md
@@ -293,38 +293,38 @@ We'll start by adding the rest of the DataLoaders that we'll need. Then we'll ad
                 .Where(s => ids.Contains(s.Id))
                 .ToDictionaryAsync(s => s.Id, cancellationToken);
         }
-    }
-
-    [DataLoader]
-    public static async Task<IReadOnlyDictionary<int, Speaker[]>> SpeakersBySessionIdAsync(
-        IReadOnlyList<int> sessionIds,
-        ApplicationDbContext dbContext,
-        CancellationToken cancellationToken)
-    {
-        return await dbContext.Sessions
-            .AsNoTracking()
-            .Where(s => sessionIds.Contains(s.Id))
-            .Select(s => new { s.Id, Speakers = s.SessionSpeakers.Select(ss => ss.Speaker) })
-            .ToDictionaryAsync(
-                s => s.Id,
-                s => s.Speakers.ToArray(),
-                cancellationToken);
-    }
-
-    [DataLoader]
-    public static async Task<IReadOnlyDictionary<int, Attendee[]>> AttendeesBySessionIdAsync(
-        IReadOnlyList<int> sessionIds,
-        ApplicationDbContext dbContext,
-        CancellationToken cancellationToken)
-    {
-        return await dbContext.Sessions
-            .AsNoTracking()
-            .Where(s => sessionIds.Contains(s.Id))
-            .Select(s => new { s.Id, Attendees = s.SessionAttendees.Select(sa => sa.Attendee) })
-            .ToDictionaryAsync(
-                s => s.Id,
-                s => s.Attendees.ToArray(),
-                cancellationToken);
+    
+        [DataLoader]
+        public static async Task<IReadOnlyDictionary<int, Speaker[]>> SpeakersBySessionIdAsync(
+            IReadOnlyList<int> sessionIds,
+            ApplicationDbContext dbContext,
+            CancellationToken cancellationToken)
+        {
+            return await dbContext.Sessions
+                .AsNoTracking()
+                .Where(s => sessionIds.Contains(s.Id))
+                .Select(s => new { s.Id, Speakers = s.SessionSpeakers.Select(ss => ss.Speaker) })
+                .ToDictionaryAsync(
+                    s => s.Id,
+                    s => s.Speakers.ToArray(),
+                    cancellationToken);
+        }
+    
+        [DataLoader]
+        public static async Task<IReadOnlyDictionary<int, Attendee[]>> AttendeesBySessionIdAsync(
+            IReadOnlyList<int> sessionIds,
+            ApplicationDbContext dbContext,
+            CancellationToken cancellationToken)
+        {
+            return await dbContext.Sessions
+                .AsNoTracking()
+                .Where(s => sessionIds.Contains(s.Id))
+                .Select(s => new { s.Id, Attendees = s.SessionAttendees.Select(sa => sa.Attendee) })
+                .ToDictionaryAsync(
+                    s => s.Id,
+                    s => s.Attendees.ToArray(),
+                    cancellationToken);
+        }
     }
     ```
 

--- a/docs/3-schema-design.md
+++ b/docs/3-schema-design.md
@@ -293,7 +293,7 @@ We'll start by adding the rest of the DataLoaders that we'll need. Then we'll ad
                 .Where(s => ids.Contains(s.Id))
                 .ToDictionaryAsync(s => s.Id, cancellationToken);
         }
-    
+
         [DataLoader]
         public static async Task<IReadOnlyDictionary<int, Speaker[]>> SpeakersBySessionIdAsync(
             IReadOnlyList<int> sessionIds,
@@ -309,7 +309,7 @@ We'll start by adding the rest of the DataLoaders that we'll need. Then we'll ad
                     s => s.Speakers.ToArray(),
                     cancellationToken);
         }
-    
+
         [DataLoader]
         public static async Task<IReadOnlyDictionary<int, Attendee[]>> AttendeesBySessionIdAsync(
             IReadOnlyList<int> sessionIds,


### PR DESCRIPTION
…s code snippet

The class-closing bracket occurred after the first method leaving the remaining methods outside of the scope of a class. This moves the class-closing bracket to the end of the code snippet.