### PR TITLE
Added DataLoader projections

### DIFF
--- a/code/session-2/GraphQL/DataLoaders.cs
+++ b/code/session-2/GraphQL/DataLoaders.cs
@@ -1,4 +1,5 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
 using Microsoft.EntityFrameworkCore;
 
 namespace ConferencePlanner.GraphQL;
@@ -9,11 +10,13 @@ public static class DataLoaders
     public static async Task<IReadOnlyDictionary<int, Speaker>> SpeakerByIdAsync(
         IReadOnlyList<int> ids,
         ApplicationDbContext dbContext,
+        ISelectorBuilder selector,
         CancellationToken cancellationToken)
     {
         return await dbContext.Speakers
             .AsNoTracking()
             .Where(s => ids.Contains(s.Id))
+            .Select(s => s.Id, selector)
             .ToDictionaryAsync(s => s.Id, cancellationToken);
     }
 
@@ -21,15 +24,13 @@ public static class DataLoaders
     public static async Task<IReadOnlyDictionary<int, Session[]>> SessionsBySpeakerIdAsync(
         IReadOnlyList<int> speakerIds,
         ApplicationDbContext dbContext,
+        ISelectorBuilder selector,
         CancellationToken cancellationToken)
     {
         return await dbContext.Speakers
             .AsNoTracking()
             .Where(s => speakerIds.Contains(s.Id))
-            .Select(s => new { s.Id, Sessions = s.SessionSpeakers.Select(ss => ss.Session) })
-            .ToDictionaryAsync(
-                s => s.Id,
-                s => s.Sessions.ToArray(),
-                cancellationToken);
+            .Select(s => s.Id, s => s.SessionSpeakers.Select(ss => ss.Session), selector)
+            .ToDictionaryAsync(r => r.Key, r => r.Value.ToArray(), cancellationToken);
     }
 }

--- a/code/session-2/GraphQL/GraphQL.csproj
+++ b/code/session-2/GraphQL/GraphQL.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>ConferencePlanner.GraphQL</RootNamespace>
+    <NoWarn>GD0001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/code/session-2/GraphQL/Queries.cs
+++ b/code/session-2/GraphQL/Queries.cs
@@ -1,4 +1,6 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
+using HotChocolate.Execution.Processing;
 using Microsoft.EntityFrameworkCore;
 
 namespace ConferencePlanner.GraphQL;
@@ -17,8 +19,9 @@ public static class Queries
     public static async Task<Speaker?> GetSpeakerAsync(
         int id,
         ISpeakerByIdDataLoader speakerById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await speakerById.LoadAsync(id, cancellationToken);
+        return await speakerById.Select(selection).LoadAsync(id, cancellationToken);
     }
 }

--- a/code/session-2/GraphQL/Types/SessionType.cs
+++ b/code/session-2/GraphQL/Types/SessionType.cs
@@ -1,0 +1,10 @@
+using ConferencePlanner.GraphQL.Data;
+
+namespace ConferencePlanner.GraphQL.Types;
+
+[ObjectType<Session>]
+public static partial class SessionType
+{
+    public static TimeSpan Duration([Parent("StartTime EndTime")] Session session)
+        => session.Duration;
+}

--- a/code/session-2/GraphQL/Types/SpeakerType.cs
+++ b/code/session-2/GraphQL/Types/SpeakerType.cs
@@ -1,4 +1,6 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
+using HotChocolate.Execution.Processing;
 
 namespace ConferencePlanner.GraphQL.Types;
 
@@ -9,8 +11,11 @@ public static partial class SpeakerType
     public static async Task<IEnumerable<Session>> GetSessionsAsync(
         [Parent] Speaker speaker,
         ISessionsBySpeakerIdDataLoader sessionsBySpeakerId,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await sessionsBySpeakerId.LoadRequiredAsync(speaker.Id, cancellationToken);
+        return await sessionsBySpeakerId
+            .Select(selection)
+            .LoadRequiredAsync(speaker.Id, cancellationToken);
     }
 }

--- a/code/session-3/GraphQL/Attendees/AttendeeType.cs
+++ b/code/session-3/GraphQL/Attendees/AttendeeType.cs
@@ -1,4 +1,6 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
+using HotChocolate.Execution.Processing;
 
 namespace ConferencePlanner.GraphQL.Attendees;
 
@@ -20,8 +22,11 @@ public static partial class AttendeeType
     public static async Task<IEnumerable<Session>> GetSessionsAsync(
         [Parent] Attendee attendee,
         ISessionsByAttendeeIdDataLoader sessionsByAttendeeId,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await sessionsByAttendeeId.LoadRequiredAsync(attendee.Id, cancellationToken);
+        return await sessionsByAttendeeId
+            .Select(selection)
+            .LoadRequiredAsync(attendee.Id, cancellationToken);
     }
 }

--- a/code/session-3/GraphQL/GraphQL.csproj
+++ b/code/session-3/GraphQL/GraphQL.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>ConferencePlanner.GraphQL</RootNamespace>
+    <NoWarn>GD0001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/code/session-3/GraphQL/Sessions/SessionQueries.cs
+++ b/code/session-3/GraphQL/Sessions/SessionQueries.cs
@@ -1,4 +1,6 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
+using HotChocolate.Execution.Processing;
 using Microsoft.EntityFrameworkCore;
 
 namespace ConferencePlanner.GraphQL.Sessions;
@@ -17,16 +19,18 @@ public static class SessionQueries
     public static async Task<Session?> GetSessionByIdAsync(
         int id,
         ISessionByIdDataLoader sessionById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await sessionById.LoadAsync(id, cancellationToken);
+        return await sessionById.Select(selection).LoadAsync(id, cancellationToken);
     }
 
     public static async Task<IEnumerable<Session>> GetSessionsByIdAsync(
         [ID<Session>] int[] ids,
         ISessionByIdDataLoader sessionById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await sessionById.LoadRequiredAsync(ids, cancellationToken);
+        return await sessionById.Select(selection).LoadRequiredAsync(ids, cancellationToken);
     }
 }

--- a/code/session-3/GraphQL/Speakers/SpeakerDataLoaders.cs
+++ b/code/session-3/GraphQL/Speakers/SpeakerDataLoaders.cs
@@ -1,4 +1,5 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
 using Microsoft.EntityFrameworkCore;
 
 namespace ConferencePlanner.GraphQL.Speakers;
@@ -9,11 +10,13 @@ public static class SpeakerDataLoaders
     public static async Task<IReadOnlyDictionary<int, Speaker>> SpeakerByIdAsync(
         IReadOnlyList<int> ids,
         ApplicationDbContext dbContext,
+        ISelectorBuilder selector,
         CancellationToken cancellationToken)
     {
         return await dbContext.Speakers
             .AsNoTracking()
             .Where(s => ids.Contains(s.Id))
+            .Select(s => s.Id, selector)
             .ToDictionaryAsync(s => s.Id, cancellationToken);
     }
 
@@ -21,15 +24,13 @@ public static class SpeakerDataLoaders
     public static async Task<IReadOnlyDictionary<int, Session[]>> SessionsBySpeakerIdAsync(
         IReadOnlyList<int> speakerIds,
         ApplicationDbContext dbContext,
+        ISelectorBuilder selector,
         CancellationToken cancellationToken)
     {
         return await dbContext.Speakers
             .AsNoTracking()
             .Where(s => speakerIds.Contains(s.Id))
-            .Select(s => new { s.Id, Sessions = s.SessionSpeakers.Select(ss => ss.Session) })
-            .ToDictionaryAsync(
-                s => s.Id,
-                s => s.Sessions.ToArray(),
-                cancellationToken);
+            .Select(s => s.Id, s => s.SessionSpeakers.Select(ss => ss.Session), selector)
+            .ToDictionaryAsync(r => r.Key, r => r.Value.ToArray(), cancellationToken);
     }
 }

--- a/code/session-3/GraphQL/Speakers/SpeakerQueries.cs
+++ b/code/session-3/GraphQL/Speakers/SpeakerQueries.cs
@@ -1,4 +1,6 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
+using HotChocolate.Execution.Processing;
 using Microsoft.EntityFrameworkCore;
 
 namespace ConferencePlanner.GraphQL.Speakers;
@@ -17,16 +19,18 @@ public static class SpeakerQueries
     public static async Task<Speaker?> GetSpeakerByIdAsync(
         int id,
         ISpeakerByIdDataLoader speakerById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await speakerById.LoadAsync(id, cancellationToken);
+        return await speakerById.Select(selection).LoadAsync(id, cancellationToken);
     }
 
     public static async Task<IEnumerable<Speaker>> GetSpeakersByIdAsync(
         [ID<Speaker>] int[] ids,
         ISpeakerByIdDataLoader speakerById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await speakerById.LoadRequiredAsync(ids, cancellationToken);
+        return await speakerById.Select(selection).LoadRequiredAsync(ids, cancellationToken);
     }
 }

--- a/code/session-3/GraphQL/Speakers/SpeakerType.cs
+++ b/code/session-3/GraphQL/Speakers/SpeakerType.cs
@@ -1,4 +1,6 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
+using HotChocolate.Execution.Processing;
 
 namespace ConferencePlanner.GraphQL.Speakers;
 
@@ -9,8 +11,11 @@ public static partial class SpeakerType
     public static async Task<IEnumerable<Session>> GetSessionsAsync(
         [Parent] Speaker speaker,
         ISessionsBySpeakerIdDataLoader sessionsBySpeakerId,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await sessionsBySpeakerId.LoadRequiredAsync(speaker.Id, cancellationToken);
+        return await sessionsBySpeakerId
+            .Select(selection)
+            .LoadRequiredAsync(speaker.Id, cancellationToken);
     }
 }

--- a/code/session-3/GraphQL/Tracks/TrackQueries.cs
+++ b/code/session-3/GraphQL/Tracks/TrackQueries.cs
@@ -1,4 +1,6 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
+using HotChocolate.Execution.Processing;
 using Microsoft.EntityFrameworkCore;
 
 namespace ConferencePlanner.GraphQL.Tracks;
@@ -17,16 +19,18 @@ public static class TrackQueries
     public static async Task<Track?> GetTrackByIdAsync(
         int id,
         ITrackByIdDataLoader trackById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await trackById.LoadAsync(id, cancellationToken);
+        return await trackById.Select(selection).LoadAsync(id, cancellationToken);
     }
 
     public static async Task<IEnumerable<Track>> GetTracksByIdAsync(
         [ID<Track>] int[] ids,
         ITrackByIdDataLoader trackById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await trackById.LoadRequiredAsync(ids, cancellationToken);
+        return await trackById.Select(selection).LoadRequiredAsync(ids, cancellationToken);
     }
 }

--- a/code/session-3/GraphQL/Tracks/TrackType.cs
+++ b/code/session-3/GraphQL/Tracks/TrackType.cs
@@ -1,4 +1,6 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
+using HotChocolate.Execution.Processing;
 
 namespace ConferencePlanner.GraphQL.Tracks;
 
@@ -8,8 +10,11 @@ public static partial class TrackType
     public static async Task<IEnumerable<Session>> GetSessionsAsync(
         [Parent] Track track,
         ISessionsByTrackIdDataLoader sessionsByTrackId,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await sessionsByTrackId.LoadRequiredAsync(track.Id, cancellationToken);
+        return await sessionsByTrackId
+            .Select(selection)
+            .LoadRequiredAsync(track.Id, cancellationToken);
     }
 }

--- a/code/session-4/GraphQL/Attendees/AttendeeType.cs
+++ b/code/session-4/GraphQL/Attendees/AttendeeType.cs
@@ -1,4 +1,6 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
+using HotChocolate.Execution.Processing;
 
 namespace ConferencePlanner.GraphQL.Attendees;
 
@@ -20,8 +22,11 @@ public static partial class AttendeeType
     public static async Task<IEnumerable<Session>> GetSessionsAsync(
         [Parent] Attendee attendee,
         ISessionsByAttendeeIdDataLoader sessionsByAttendeeId,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await sessionsByAttendeeId.LoadRequiredAsync(attendee.Id, cancellationToken);
+        return await sessionsByAttendeeId
+            .Select(selection)
+            .LoadRequiredAsync(attendee.Id, cancellationToken);
     }
 }

--- a/code/session-4/GraphQL/GraphQL.csproj
+++ b/code/session-4/GraphQL/GraphQL.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>ConferencePlanner.GraphQL</RootNamespace>
+    <NoWarn>GD0001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/code/session-4/GraphQL/Sessions/SessionQueries.cs
+++ b/code/session-4/GraphQL/Sessions/SessionQueries.cs
@@ -1,4 +1,6 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
+using HotChocolate.Execution.Processing;
 using Microsoft.EntityFrameworkCore;
 
 namespace ConferencePlanner.GraphQL.Sessions;
@@ -17,16 +19,18 @@ public static class SessionQueries
     public static async Task<Session?> GetSessionByIdAsync(
         int id,
         ISessionByIdDataLoader sessionById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await sessionById.LoadAsync(id, cancellationToken);
+        return await sessionById.Select(selection).LoadAsync(id, cancellationToken);
     }
 
     public static async Task<IEnumerable<Session>> GetSessionsByIdAsync(
         [ID<Session>] int[] ids,
         ISessionByIdDataLoader sessionById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await sessionById.LoadRequiredAsync(ids, cancellationToken);
+        return await sessionById.Select(selection).LoadRequiredAsync(ids, cancellationToken);
     }
 }

--- a/code/session-4/GraphQL/Speakers/SpeakerDataLoaders.cs
+++ b/code/session-4/GraphQL/Speakers/SpeakerDataLoaders.cs
@@ -1,4 +1,5 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
 using Microsoft.EntityFrameworkCore;
 
 namespace ConferencePlanner.GraphQL.Speakers;
@@ -9,11 +10,13 @@ public static class SpeakerDataLoaders
     public static async Task<IReadOnlyDictionary<int, Speaker>> SpeakerByIdAsync(
         IReadOnlyList<int> ids,
         ApplicationDbContext dbContext,
+        ISelectorBuilder selector,
         CancellationToken cancellationToken)
     {
         return await dbContext.Speakers
             .AsNoTracking()
             .Where(s => ids.Contains(s.Id))
+            .Select(s => s.Id, selector)
             .ToDictionaryAsync(s => s.Id, cancellationToken);
     }
 
@@ -21,15 +24,13 @@ public static class SpeakerDataLoaders
     public static async Task<IReadOnlyDictionary<int, Session[]>> SessionsBySpeakerIdAsync(
         IReadOnlyList<int> speakerIds,
         ApplicationDbContext dbContext,
+        ISelectorBuilder selector,
         CancellationToken cancellationToken)
     {
         return await dbContext.Speakers
             .AsNoTracking()
             .Where(s => speakerIds.Contains(s.Id))
-            .Select(s => new { s.Id, Sessions = s.SessionSpeakers.Select(ss => ss.Session) })
-            .ToDictionaryAsync(
-                s => s.Id,
-                s => s.Sessions.ToArray(),
-                cancellationToken);
+            .Select(s => s.Id, s => s.SessionSpeakers.Select(ss => ss.Session), selector)
+            .ToDictionaryAsync(r => r.Key, r => r.Value.ToArray(), cancellationToken);
     }
 }

--- a/code/session-4/GraphQL/Speakers/SpeakerQueries.cs
+++ b/code/session-4/GraphQL/Speakers/SpeakerQueries.cs
@@ -1,4 +1,6 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
+using HotChocolate.Execution.Processing;
 using Microsoft.EntityFrameworkCore;
 
 namespace ConferencePlanner.GraphQL.Speakers;
@@ -17,16 +19,18 @@ public static class SpeakerQueries
     public static async Task<Speaker?> GetSpeakerByIdAsync(
         int id,
         ISpeakerByIdDataLoader speakerById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await speakerById.LoadAsync(id, cancellationToken);
+        return await speakerById.Select(selection).LoadAsync(id, cancellationToken);
     }
 
     public static async Task<IEnumerable<Speaker>> GetSpeakersByIdAsync(
         [ID<Speaker>] int[] ids,
         ISpeakerByIdDataLoader speakerById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await speakerById.LoadRequiredAsync(ids, cancellationToken);
+        return await speakerById.Select(selection).LoadRequiredAsync(ids, cancellationToken);
     }
 }

--- a/code/session-4/GraphQL/Speakers/SpeakerType.cs
+++ b/code/session-4/GraphQL/Speakers/SpeakerType.cs
@@ -1,4 +1,6 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
+using HotChocolate.Execution.Processing;
 
 namespace ConferencePlanner.GraphQL.Speakers;
 
@@ -9,8 +11,11 @@ public static partial class SpeakerType
     public static async Task<IEnumerable<Session>> GetSessionsAsync(
         [Parent] Speaker speaker,
         ISessionsBySpeakerIdDataLoader sessionsBySpeakerId,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await sessionsBySpeakerId.LoadRequiredAsync(speaker.Id, cancellationToken);
+        return await sessionsBySpeakerId
+            .Select(selection)
+            .LoadRequiredAsync(speaker.Id, cancellationToken);
     }
 }

--- a/code/session-4/GraphQL/Tracks/TrackQueries.cs
+++ b/code/session-4/GraphQL/Tracks/TrackQueries.cs
@@ -1,4 +1,6 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
+using HotChocolate.Execution.Processing;
 using Microsoft.EntityFrameworkCore;
 
 namespace ConferencePlanner.GraphQL.Tracks;
@@ -17,16 +19,18 @@ public static class TrackQueries
     public static async Task<Track?> GetTrackByIdAsync(
         int id,
         ITrackByIdDataLoader trackById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await trackById.LoadAsync(id, cancellationToken);
+        return await trackById.Select(selection).LoadAsync(id, cancellationToken);
     }
 
     public static async Task<IEnumerable<Track>> GetTracksByIdAsync(
         [ID<Track>] int[] ids,
         ITrackByIdDataLoader trackById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await trackById.LoadRequiredAsync(ids, cancellationToken);
+        return await trackById.Select(selection).LoadRequiredAsync(ids, cancellationToken);
     }
 }

--- a/code/session-4/GraphQL/Tracks/TrackType.cs
+++ b/code/session-4/GraphQL/Tracks/TrackType.cs
@@ -12,6 +12,7 @@ public static partial class TrackType
     {
         descriptor
             .Field(t => t.Name)
+            .ParentRequires(nameof(Track.Name))
             .UseUpperCase();
     }
 

--- a/code/session-4/GraphQL/Tracks/TrackType.cs
+++ b/code/session-4/GraphQL/Tracks/TrackType.cs
@@ -1,5 +1,7 @@
 using ConferencePlanner.GraphQL.Data;
 using ConferencePlanner.GraphQL.Extensions;
+using GreenDonut.Projections;
+using HotChocolate.Execution.Processing;
 
 namespace ConferencePlanner.GraphQL.Tracks;
 
@@ -16,8 +18,11 @@ public static partial class TrackType
     public static async Task<IEnumerable<Session>> GetSessionsAsync(
         [Parent] Track track,
         ISessionsByTrackIdDataLoader sessionsByTrackId,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await sessionsByTrackId.LoadRequiredAsync(track.Id, cancellationToken);
+        return await sessionsByTrackId
+            .Select(selection)
+            .LoadRequiredAsync(track.Id, cancellationToken);
     }
 }

--- a/code/session-5/GraphQL/Attendees/AttendeeType.cs
+++ b/code/session-5/GraphQL/Attendees/AttendeeType.cs
@@ -1,4 +1,6 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
+using HotChocolate.Execution.Processing;
 
 namespace ConferencePlanner.GraphQL.Attendees;
 
@@ -20,8 +22,11 @@ public static partial class AttendeeType
     public static async Task<IEnumerable<Session>> GetSessionsAsync(
         [Parent] Attendee attendee,
         ISessionsByAttendeeIdDataLoader sessionsByAttendeeId,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await sessionsByAttendeeId.LoadRequiredAsync(attendee.Id, cancellationToken);
+        return await sessionsByAttendeeId
+            .Select(selection)
+            .LoadRequiredAsync(attendee.Id, cancellationToken);
     }
 }

--- a/code/session-5/GraphQL/GraphQL.csproj
+++ b/code/session-5/GraphQL/GraphQL.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>ConferencePlanner.GraphQL</RootNamespace>
+    <NoWarn>GD0001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/code/session-5/GraphQL/Sessions/SessionQueries.cs
+++ b/code/session-5/GraphQL/Sessions/SessionQueries.cs
@@ -1,4 +1,6 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
+using HotChocolate.Execution.Processing;
 using Microsoft.EntityFrameworkCore;
 
 namespace ConferencePlanner.GraphQL.Sessions;
@@ -18,16 +20,18 @@ public static class SessionQueries
     public static async Task<Session?> GetSessionByIdAsync(
         int id,
         ISessionByIdDataLoader sessionById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await sessionById.LoadAsync(id, cancellationToken);
+        return await sessionById.Select(selection).LoadAsync(id, cancellationToken);
     }
 
     public static async Task<IEnumerable<Session>> GetSessionsByIdAsync(
         [ID<Session>] int[] ids,
         ISessionByIdDataLoader sessionById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await sessionById.LoadRequiredAsync(ids, cancellationToken);
+        return await sessionById.Select(selection).LoadRequiredAsync(ids, cancellationToken);
     }
 }

--- a/code/session-5/GraphQL/Speakers/SpeakerDataLoaders.cs
+++ b/code/session-5/GraphQL/Speakers/SpeakerDataLoaders.cs
@@ -1,4 +1,5 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
 using Microsoft.EntityFrameworkCore;
 
 namespace ConferencePlanner.GraphQL.Speakers;
@@ -9,11 +10,13 @@ public static class SpeakerDataLoaders
     public static async Task<IReadOnlyDictionary<int, Speaker>> SpeakerByIdAsync(
         IReadOnlyList<int> ids,
         ApplicationDbContext dbContext,
+        ISelectorBuilder selector,
         CancellationToken cancellationToken)
     {
         return await dbContext.Speakers
             .AsNoTracking()
             .Where(s => ids.Contains(s.Id))
+            .Select(s => s.Id, selector)
             .ToDictionaryAsync(s => s.Id, cancellationToken);
     }
 
@@ -21,15 +24,13 @@ public static class SpeakerDataLoaders
     public static async Task<IReadOnlyDictionary<int, Session[]>> SessionsBySpeakerIdAsync(
         IReadOnlyList<int> speakerIds,
         ApplicationDbContext dbContext,
+        ISelectorBuilder selector,
         CancellationToken cancellationToken)
     {
         return await dbContext.Speakers
             .AsNoTracking()
             .Where(s => speakerIds.Contains(s.Id))
-            .Select(s => new { s.Id, Sessions = s.SessionSpeakers.Select(ss => ss.Session) })
-            .ToDictionaryAsync(
-                s => s.Id,
-                s => s.Sessions.ToArray(),
-                cancellationToken);
+            .Select(s => s.Id, s => s.SessionSpeakers.Select(ss => ss.Session), selector)
+            .ToDictionaryAsync(r => r.Key, r => r.Value.ToArray(), cancellationToken);
     }
 }

--- a/code/session-5/GraphQL/Speakers/SpeakerQueries.cs
+++ b/code/session-5/GraphQL/Speakers/SpeakerQueries.cs
@@ -1,4 +1,6 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
+using HotChocolate.Execution.Processing;
 using Microsoft.EntityFrameworkCore;
 
 namespace ConferencePlanner.GraphQL.Speakers;
@@ -16,16 +18,18 @@ public static class SpeakerQueries
     public static async Task<Speaker?> GetSpeakerByIdAsync(
         int id,
         ISpeakerByIdDataLoader speakerById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await speakerById.LoadAsync(id, cancellationToken);
+        return await speakerById.Select(selection).LoadAsync(id, cancellationToken);
     }
 
     public static async Task<IEnumerable<Speaker>> GetSpeakersByIdAsync(
         [ID<Speaker>] int[] ids,
         ISpeakerByIdDataLoader speakerById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await speakerById.LoadRequiredAsync(ids, cancellationToken);
+        return await speakerById.Select(selection).LoadRequiredAsync(ids, cancellationToken);
     }
 }

--- a/code/session-5/GraphQL/Speakers/SpeakerType.cs
+++ b/code/session-5/GraphQL/Speakers/SpeakerType.cs
@@ -1,4 +1,6 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
+using HotChocolate.Execution.Processing;
 
 namespace ConferencePlanner.GraphQL.Speakers;
 
@@ -9,8 +11,11 @@ public static partial class SpeakerType
     public static async Task<IEnumerable<Session>> GetSessionsAsync(
         [Parent] Speaker speaker,
         ISessionsBySpeakerIdDataLoader sessionsBySpeakerId,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await sessionsBySpeakerId.LoadRequiredAsync(speaker.Id, cancellationToken);
+        return await sessionsBySpeakerId
+            .Select(selection)
+            .LoadRequiredAsync(speaker.Id, cancellationToken);
     }
 }

--- a/code/session-5/GraphQL/Tracks/TrackDataLoaders.cs
+++ b/code/session-5/GraphQL/Tracks/TrackDataLoaders.cs
@@ -33,7 +33,7 @@ public static class TrackDataLoaders
             .AsNoTracking()
             .Where(s => s.TrackId != null && trackIds.Contains((int)s.TrackId))
             .OrderBy(s => s.Id)
-            .Select(s => s.Id, selector)
+            .Select(s => s.TrackId, selector)
             .ToBatchPageAsync(s => (int)s.TrackId!, pagingArguments, cancellationToken);
     }
 }

--- a/code/session-5/GraphQL/Tracks/TrackDataLoaders.cs
+++ b/code/session-5/GraphQL/Tracks/TrackDataLoaders.cs
@@ -1,4 +1,5 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
 using HotChocolate.Pagination;
 using Microsoft.EntityFrameworkCore;
 
@@ -10,11 +11,13 @@ public static class TrackDataLoaders
     public static async Task<IReadOnlyDictionary<int, Track>> TrackByIdAsync(
         IReadOnlyList<int> ids,
         ApplicationDbContext dbContext,
+        ISelectorBuilder selector,
         CancellationToken cancellationToken)
     {
         return await dbContext.Tracks
             .AsNoTracking()
             .Where(t => ids.Contains(t.Id))
+            .Select(t => t.Id, selector)
             .ToDictionaryAsync(t => t.Id, cancellationToken);
     }
 
@@ -22,6 +25,7 @@ public static class TrackDataLoaders
     public static async Task<IReadOnlyDictionary<int, Page<Session>>> SessionsByTrackIdAsync(
         IReadOnlyList<int> trackIds,
         ApplicationDbContext dbContext,
+        ISelectorBuilder selector,
         PagingArguments pagingArguments,
         CancellationToken cancellationToken)
     {
@@ -29,6 +33,7 @@ public static class TrackDataLoaders
             .AsNoTracking()
             .Where(s => s.TrackId != null && trackIds.Contains((int)s.TrackId))
             .OrderBy(s => s.Id)
+            .Select(s => s.Id, selector)
             .ToBatchPageAsync(s => (int)s.TrackId!, pagingArguments, cancellationToken);
     }
 }

--- a/code/session-5/GraphQL/Tracks/TrackQueries.cs
+++ b/code/session-5/GraphQL/Tracks/TrackQueries.cs
@@ -1,4 +1,6 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
+using HotChocolate.Execution.Processing;
 using Microsoft.EntityFrameworkCore;
 
 namespace ConferencePlanner.GraphQL.Tracks;
@@ -16,16 +18,18 @@ public static class TrackQueries
     public static async Task<Track?> GetTrackByIdAsync(
         int id,
         ITrackByIdDataLoader trackById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await trackById.LoadAsync(id, cancellationToken);
+        return await trackById.Select(selection).LoadAsync(id, cancellationToken);
     }
 
     public static async Task<IEnumerable<Track>> GetTracksByIdAsync(
         [ID<Track>] int[] ids,
         ITrackByIdDataLoader trackById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await trackById.LoadRequiredAsync(ids, cancellationToken);
+        return await trackById.Select(selection).LoadRequiredAsync(ids, cancellationToken);
     }
 }

--- a/code/session-5/GraphQL/Tracks/TrackType.cs
+++ b/code/session-5/GraphQL/Tracks/TrackType.cs
@@ -14,6 +14,7 @@ public static partial class TrackType
     {
         descriptor
             .Field(t => t.Name)
+            .ParentRequires(nameof(Track.Name))
             .UseUpperCase();
     }
 

--- a/code/session-5/GraphQL/Tracks/TrackType.cs
+++ b/code/session-5/GraphQL/Tracks/TrackType.cs
@@ -1,6 +1,7 @@
 using ConferencePlanner.GraphQL.Data;
 using ConferencePlanner.GraphQL.Extensions;
 using GreenDonut.Projections;
+using HotChocolate.Execution.Processing;
 using HotChocolate.Pagination;
 using HotChocolate.Types.Pagination;
 
@@ -21,10 +22,12 @@ public static partial class TrackType
         [Parent] Track track,
         ISessionsByTrackIdDataLoader sessionsByTrackId,
         PagingArguments pagingArguments,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
         return await sessionsByTrackId
             .WithPagingArguments(pagingArguments)
+            .Select(selection)
             .LoadAsync(track.Id, cancellationToken)
             .ToConnectionAsync();
     }

--- a/code/session-6/GraphQL/Attendees/AttendeeQueries.cs
+++ b/code/session-6/GraphQL/Attendees/AttendeeQueries.cs
@@ -1,4 +1,6 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
+using HotChocolate.Execution.Processing;
 using Microsoft.EntityFrameworkCore;
 
 namespace ConferencePlanner.GraphQL.Attendees;
@@ -16,16 +18,18 @@ public static class AttendeeQueries
     public static async Task<Attendee?> GetAttendeeByIdAsync(
         int id,
         IAttendeeByIdDataLoader attendeeById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await attendeeById.LoadAsync(id, cancellationToken);
+        return await attendeeById.Select(selection).LoadAsync(id, cancellationToken);
     }
 
     public static async Task<IEnumerable<Attendee>> GetAttendeesByIdAsync(
         [ID<Attendee>] int[] ids,
         IAttendeeByIdDataLoader attendeeById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await attendeeById.LoadRequiredAsync(ids, cancellationToken);
+        return await attendeeById.Select(selection).LoadRequiredAsync(ids, cancellationToken);
     }
 }

--- a/code/session-6/GraphQL/Attendees/AttendeeType.cs
+++ b/code/session-6/GraphQL/Attendees/AttendeeType.cs
@@ -1,4 +1,6 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
+using HotChocolate.Execution.Processing;
 
 namespace ConferencePlanner.GraphQL.Attendees;
 
@@ -20,8 +22,11 @@ public static partial class AttendeeType
     public static async Task<IEnumerable<Session>> GetSessionsAsync(
         [Parent] Attendee attendee,
         ISessionsByAttendeeIdDataLoader sessionsByAttendeeId,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await sessionsByAttendeeId.LoadRequiredAsync(attendee.Id, cancellationToken);
+        return await sessionsByAttendeeId
+            .Select(selection)
+            .LoadRequiredAsync(attendee.Id, cancellationToken);
     }
 }

--- a/code/session-6/GraphQL/GraphQL.csproj
+++ b/code/session-6/GraphQL/GraphQL.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>ConferencePlanner.GraphQL</RootNamespace>
+    <NoWarn>GD0001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/code/session-6/GraphQL/Sessions/SessionQueries.cs
+++ b/code/session-6/GraphQL/Sessions/SessionQueries.cs
@@ -1,4 +1,6 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
+using HotChocolate.Execution.Processing;
 using Microsoft.EntityFrameworkCore;
 
 namespace ConferencePlanner.GraphQL.Sessions;
@@ -18,16 +20,18 @@ public static class SessionQueries
     public static async Task<Session?> GetSessionByIdAsync(
         int id,
         ISessionByIdDataLoader sessionById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await sessionById.LoadAsync(id, cancellationToken);
+        return await sessionById.Select(selection).LoadAsync(id, cancellationToken);
     }
 
     public static async Task<IEnumerable<Session>> GetSessionsByIdAsync(
         [ID<Session>] int[] ids,
         ISessionByIdDataLoader sessionById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await sessionById.LoadRequiredAsync(ids, cancellationToken);
+        return await sessionById.Select(selection).LoadRequiredAsync(ids, cancellationToken);
     }
 }

--- a/code/session-6/GraphQL/Speakers/SpeakerDataLoaders.cs
+++ b/code/session-6/GraphQL/Speakers/SpeakerDataLoaders.cs
@@ -1,4 +1,5 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
 using Microsoft.EntityFrameworkCore;
 
 namespace ConferencePlanner.GraphQL.Speakers;
@@ -9,11 +10,13 @@ public static class SpeakerDataLoaders
     public static async Task<IReadOnlyDictionary<int, Speaker>> SpeakerByIdAsync(
         IReadOnlyList<int> ids,
         ApplicationDbContext dbContext,
+        ISelectorBuilder selector,
         CancellationToken cancellationToken)
     {
         return await dbContext.Speakers
             .AsNoTracking()
             .Where(s => ids.Contains(s.Id))
+            .Select(s => s.Id, selector)
             .ToDictionaryAsync(s => s.Id, cancellationToken);
     }
 
@@ -21,15 +24,13 @@ public static class SpeakerDataLoaders
     public static async Task<IReadOnlyDictionary<int, Session[]>> SessionsBySpeakerIdAsync(
         IReadOnlyList<int> speakerIds,
         ApplicationDbContext dbContext,
+        ISelectorBuilder selector,
         CancellationToken cancellationToken)
     {
         return await dbContext.Speakers
             .AsNoTracking()
             .Where(s => speakerIds.Contains(s.Id))
-            .Select(s => new { s.Id, Sessions = s.SessionSpeakers.Select(ss => ss.Session) })
-            .ToDictionaryAsync(
-                s => s.Id,
-                s => s.Sessions.ToArray(),
-                cancellationToken);
+            .Select(s => s.Id, s => s.SessionSpeakers.Select(ss => ss.Session), selector)
+            .ToDictionaryAsync(r => r.Key, r => r.Value.ToArray(), cancellationToken);
     }
 }

--- a/code/session-6/GraphQL/Speakers/SpeakerQueries.cs
+++ b/code/session-6/GraphQL/Speakers/SpeakerQueries.cs
@@ -1,4 +1,6 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
+using HotChocolate.Execution.Processing;
 using Microsoft.EntityFrameworkCore;
 
 namespace ConferencePlanner.GraphQL.Speakers;
@@ -16,16 +18,18 @@ public static class SpeakerQueries
     public static async Task<Speaker?> GetSpeakerByIdAsync(
         int id,
         ISpeakerByIdDataLoader speakerById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await speakerById.LoadAsync(id, cancellationToken);
+        return await speakerById.Select(selection).LoadAsync(id, cancellationToken);
     }
 
     public static async Task<IEnumerable<Speaker>> GetSpeakersByIdAsync(
         [ID<Speaker>] int[] ids,
         ISpeakerByIdDataLoader speakerById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await speakerById.LoadRequiredAsync(ids, cancellationToken);
+        return await speakerById.Select(selection).LoadRequiredAsync(ids, cancellationToken);
     }
 }

--- a/code/session-6/GraphQL/Speakers/SpeakerType.cs
+++ b/code/session-6/GraphQL/Speakers/SpeakerType.cs
@@ -1,4 +1,6 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
+using HotChocolate.Execution.Processing;
 
 namespace ConferencePlanner.GraphQL.Speakers;
 
@@ -9,8 +11,11 @@ public static partial class SpeakerType
     public static async Task<IEnumerable<Session>> GetSessionsAsync(
         [Parent] Speaker speaker,
         ISessionsBySpeakerIdDataLoader sessionsBySpeakerId,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await sessionsBySpeakerId.LoadRequiredAsync(speaker.Id, cancellationToken);
+        return await sessionsBySpeakerId
+            .Select(selection)
+            .LoadRequiredAsync(speaker.Id, cancellationToken);
     }
 }

--- a/code/session-6/GraphQL/Tracks/TrackDataLoaders.cs
+++ b/code/session-6/GraphQL/Tracks/TrackDataLoaders.cs
@@ -33,7 +33,7 @@ public static class TrackDataLoaders
             .AsNoTracking()
             .Where(s => s.TrackId != null && trackIds.Contains((int)s.TrackId))
             .OrderBy(s => s.Id)
-            .Select(s => s.Id, selector)
+            .Select(s => s.TrackId, selector)
             .ToBatchPageAsync(s => (int)s.TrackId!, pagingArguments, cancellationToken);
     }
 }

--- a/code/session-6/GraphQL/Tracks/TrackDataLoaders.cs
+++ b/code/session-6/GraphQL/Tracks/TrackDataLoaders.cs
@@ -1,4 +1,5 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
 using HotChocolate.Pagination;
 using Microsoft.EntityFrameworkCore;
 
@@ -10,11 +11,13 @@ public static class TrackDataLoaders
     public static async Task<IReadOnlyDictionary<int, Track>> TrackByIdAsync(
         IReadOnlyList<int> ids,
         ApplicationDbContext dbContext,
+        ISelectorBuilder selector,
         CancellationToken cancellationToken)
     {
         return await dbContext.Tracks
             .AsNoTracking()
             .Where(t => ids.Contains(t.Id))
+            .Select(t => t.Id, selector)
             .ToDictionaryAsync(t => t.Id, cancellationToken);
     }
 
@@ -22,6 +25,7 @@ public static class TrackDataLoaders
     public static async Task<IReadOnlyDictionary<int, Page<Session>>> SessionsByTrackIdAsync(
         IReadOnlyList<int> trackIds,
         ApplicationDbContext dbContext,
+        ISelectorBuilder selector,
         PagingArguments pagingArguments,
         CancellationToken cancellationToken)
     {
@@ -29,6 +33,7 @@ public static class TrackDataLoaders
             .AsNoTracking()
             .Where(s => s.TrackId != null && trackIds.Contains((int)s.TrackId))
             .OrderBy(s => s.Id)
+            .Select(s => s.Id, selector)
             .ToBatchPageAsync(s => (int)s.TrackId!, pagingArguments, cancellationToken);
     }
 }

--- a/code/session-6/GraphQL/Tracks/TrackQueries.cs
+++ b/code/session-6/GraphQL/Tracks/TrackQueries.cs
@@ -1,4 +1,6 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
+using HotChocolate.Execution.Processing;
 using Microsoft.EntityFrameworkCore;
 
 namespace ConferencePlanner.GraphQL.Tracks;
@@ -16,16 +18,18 @@ public static class TrackQueries
     public static async Task<Track?> GetTrackByIdAsync(
         int id,
         ITrackByIdDataLoader trackById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await trackById.LoadAsync(id, cancellationToken);
+        return await trackById.Select(selection).LoadAsync(id, cancellationToken);
     }
 
     public static async Task<IEnumerable<Track>> GetTracksByIdAsync(
         [ID<Track>] int[] ids,
         ITrackByIdDataLoader trackById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await trackById.LoadRequiredAsync(ids, cancellationToken);
+        return await trackById.Select(selection).LoadRequiredAsync(ids, cancellationToken);
     }
 }

--- a/code/session-6/GraphQL/Tracks/TrackType.cs
+++ b/code/session-6/GraphQL/Tracks/TrackType.cs
@@ -14,6 +14,7 @@ public static partial class TrackType
     {
         descriptor
             .Field(t => t.Name)
+            .ParentRequires(nameof(Track.Name))
             .UseUpperCase();
     }
 

--- a/code/session-6/GraphQL/Tracks/TrackType.cs
+++ b/code/session-6/GraphQL/Tracks/TrackType.cs
@@ -1,6 +1,7 @@
 using ConferencePlanner.GraphQL.Data;
 using ConferencePlanner.GraphQL.Extensions;
 using GreenDonut.Projections;
+using HotChocolate.Execution.Processing;
 using HotChocolate.Pagination;
 using HotChocolate.Types.Pagination;
 
@@ -21,10 +22,12 @@ public static partial class TrackType
         [Parent] Track track,
         ISessionsByTrackIdDataLoader sessionsByTrackId,
         PagingArguments pagingArguments,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
         return await sessionsByTrackId
             .WithPagingArguments(pagingArguments)
+            .Select(selection)
             .LoadAsync(track.Id, cancellationToken)
             .ToConnectionAsync();
     }

--- a/code/session-7/GraphQL.Tests/__snapshots__/SchemaTests.SchemaChanged.graphql
+++ b/code/session-7/GraphQL.Tests/__snapshots__/SchemaTests.SchemaChanged.graphql
@@ -121,6 +121,7 @@ type ScheduleSessionPayload {
 }
 
 type Session implements Node {
+  duration: TimeSpan!
   speakers: [Speaker!]! @cost(weight: "10")
   attendees: [Attendee!]! @cost(weight: "10")
   track: Track @cost(weight: "10")
@@ -130,7 +131,6 @@ type Session implements Node {
   abstract: String
   startTime: DateTime
   endTime: DateTime
-  duration: TimeSpan!
 }
 
 type SessionAttendeeCheckIn {

--- a/code/session-7/GraphQL/Attendees/AttendeeQueries.cs
+++ b/code/session-7/GraphQL/Attendees/AttendeeQueries.cs
@@ -1,4 +1,6 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
+using HotChocolate.Execution.Processing;
 using Microsoft.EntityFrameworkCore;
 
 namespace ConferencePlanner.GraphQL.Attendees;
@@ -16,16 +18,18 @@ public static class AttendeeQueries
     public static async Task<Attendee?> GetAttendeeByIdAsync(
         int id,
         IAttendeeByIdDataLoader attendeeById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await attendeeById.LoadAsync(id, cancellationToken);
+        return await attendeeById.Select(selection).LoadAsync(id, cancellationToken);
     }
 
     public static async Task<IEnumerable<Attendee>> GetAttendeesByIdAsync(
         [ID<Attendee>] int[] ids,
         IAttendeeByIdDataLoader attendeeById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await attendeeById.LoadRequiredAsync(ids, cancellationToken);
+        return await attendeeById.Select(selection).LoadRequiredAsync(ids, cancellationToken);
     }
 }

--- a/code/session-7/GraphQL/Attendees/AttendeeType.cs
+++ b/code/session-7/GraphQL/Attendees/AttendeeType.cs
@@ -1,4 +1,6 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
+using HotChocolate.Execution.Processing;
 
 namespace ConferencePlanner.GraphQL.Attendees;
 
@@ -20,8 +22,11 @@ public static partial class AttendeeType
     public static async Task<IEnumerable<Session>> GetSessionsAsync(
         [Parent] Attendee attendee,
         ISessionsByAttendeeIdDataLoader sessionsByAttendeeId,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await sessionsByAttendeeId.LoadRequiredAsync(attendee.Id, cancellationToken);
+        return await sessionsByAttendeeId
+            .Select(selection)
+            .LoadRequiredAsync(attendee.Id, cancellationToken);
     }
 }

--- a/code/session-7/GraphQL/GraphQL.csproj
+++ b/code/session-7/GraphQL/GraphQL.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>ConferencePlanner.GraphQL</RootNamespace>
+    <NoWarn>GD0001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/code/session-7/GraphQL/Sessions/SessionQueries.cs
+++ b/code/session-7/GraphQL/Sessions/SessionQueries.cs
@@ -1,4 +1,6 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
+using HotChocolate.Execution.Processing;
 using Microsoft.EntityFrameworkCore;
 
 namespace ConferencePlanner.GraphQL.Sessions;
@@ -18,16 +20,18 @@ public static class SessionQueries
     public static async Task<Session?> GetSessionByIdAsync(
         int id,
         ISessionByIdDataLoader sessionById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await sessionById.LoadAsync(id, cancellationToken);
+        return await sessionById.Select(selection).LoadAsync(id, cancellationToken);
     }
 
     public static async Task<IEnumerable<Session>> GetSessionsByIdAsync(
         [ID<Session>] int[] ids,
         ISessionByIdDataLoader sessionById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await sessionById.LoadRequiredAsync(ids, cancellationToken);
+        return await sessionById.Select(selection).LoadRequiredAsync(ids, cancellationToken);
     }
 }

--- a/code/session-7/GraphQL/Speakers/SpeakerDataLoaders.cs
+++ b/code/session-7/GraphQL/Speakers/SpeakerDataLoaders.cs
@@ -1,4 +1,5 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
 using Microsoft.EntityFrameworkCore;
 
 namespace ConferencePlanner.GraphQL.Speakers;
@@ -9,11 +10,13 @@ public static class SpeakerDataLoaders
     public static async Task<IReadOnlyDictionary<int, Speaker>> SpeakerByIdAsync(
         IReadOnlyList<int> ids,
         ApplicationDbContext dbContext,
+        ISelectorBuilder selector,
         CancellationToken cancellationToken)
     {
         return await dbContext.Speakers
             .AsNoTracking()
             .Where(s => ids.Contains(s.Id))
+            .Select(s => s.Id, selector)
             .ToDictionaryAsync(s => s.Id, cancellationToken);
     }
 
@@ -21,15 +24,13 @@ public static class SpeakerDataLoaders
     public static async Task<IReadOnlyDictionary<int, Session[]>> SessionsBySpeakerIdAsync(
         IReadOnlyList<int> speakerIds,
         ApplicationDbContext dbContext,
+        ISelectorBuilder selector,
         CancellationToken cancellationToken)
     {
         return await dbContext.Speakers
             .AsNoTracking()
             .Where(s => speakerIds.Contains(s.Id))
-            .Select(s => new { s.Id, Sessions = s.SessionSpeakers.Select(ss => ss.Session) })
-            .ToDictionaryAsync(
-                s => s.Id,
-                s => s.Sessions.ToArray(),
-                cancellationToken);
+            .Select(s => s.Id, s => s.SessionSpeakers.Select(ss => ss.Session), selector)
+            .ToDictionaryAsync(r => r.Key, r => r.Value.ToArray(), cancellationToken);
     }
 }

--- a/code/session-7/GraphQL/Speakers/SpeakerQueries.cs
+++ b/code/session-7/GraphQL/Speakers/SpeakerQueries.cs
@@ -1,4 +1,6 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
+using HotChocolate.Execution.Processing;
 using Microsoft.EntityFrameworkCore;
 
 namespace ConferencePlanner.GraphQL.Speakers;
@@ -16,16 +18,18 @@ public static class SpeakerQueries
     public static async Task<Speaker?> GetSpeakerByIdAsync(
         int id,
         ISpeakerByIdDataLoader speakerById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await speakerById.LoadAsync(id, cancellationToken);
+        return await speakerById.Select(selection).LoadAsync(id, cancellationToken);
     }
 
     public static async Task<IEnumerable<Speaker>> GetSpeakersByIdAsync(
         [ID<Speaker>] int[] ids,
         ISpeakerByIdDataLoader speakerById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await speakerById.LoadRequiredAsync(ids, cancellationToken);
+        return await speakerById.Select(selection).LoadRequiredAsync(ids, cancellationToken);
     }
 }

--- a/code/session-7/GraphQL/Speakers/SpeakerType.cs
+++ b/code/session-7/GraphQL/Speakers/SpeakerType.cs
@@ -1,4 +1,6 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
+using HotChocolate.Execution.Processing;
 
 namespace ConferencePlanner.GraphQL.Speakers;
 
@@ -9,8 +11,11 @@ public static partial class SpeakerType
     public static async Task<IEnumerable<Session>> GetSessionsAsync(
         [Parent] Speaker speaker,
         ISessionsBySpeakerIdDataLoader sessionsBySpeakerId,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await sessionsBySpeakerId.LoadRequiredAsync(speaker.Id, cancellationToken);
+        return await sessionsBySpeakerId
+            .Select(selection)
+            .LoadRequiredAsync(speaker.Id, cancellationToken);
     }
 }

--- a/code/session-7/GraphQL/Tracks/TrackDataLoaders.cs
+++ b/code/session-7/GraphQL/Tracks/TrackDataLoaders.cs
@@ -33,7 +33,7 @@ public static class TrackDataLoaders
             .AsNoTracking()
             .Where(s => s.TrackId != null && trackIds.Contains((int)s.TrackId))
             .OrderBy(s => s.Id)
-            .Select(s => s.Id, selector)
+            .Select(s => s.TrackId, selector)
             .ToBatchPageAsync(s => (int)s.TrackId!, pagingArguments, cancellationToken);
     }
 }

--- a/code/session-7/GraphQL/Tracks/TrackDataLoaders.cs
+++ b/code/session-7/GraphQL/Tracks/TrackDataLoaders.cs
@@ -1,4 +1,5 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
 using HotChocolate.Pagination;
 using Microsoft.EntityFrameworkCore;
 
@@ -10,11 +11,13 @@ public static class TrackDataLoaders
     public static async Task<IReadOnlyDictionary<int, Track>> TrackByIdAsync(
         IReadOnlyList<int> ids,
         ApplicationDbContext dbContext,
+        ISelectorBuilder selector,
         CancellationToken cancellationToken)
     {
         return await dbContext.Tracks
             .AsNoTracking()
             .Where(t => ids.Contains(t.Id))
+            .Select(t => t.Id, selector)
             .ToDictionaryAsync(t => t.Id, cancellationToken);
     }
 
@@ -22,6 +25,7 @@ public static class TrackDataLoaders
     public static async Task<IReadOnlyDictionary<int, Page<Session>>> SessionsByTrackIdAsync(
         IReadOnlyList<int> trackIds,
         ApplicationDbContext dbContext,
+        ISelectorBuilder selector,
         PagingArguments pagingArguments,
         CancellationToken cancellationToken)
     {
@@ -29,6 +33,7 @@ public static class TrackDataLoaders
             .AsNoTracking()
             .Where(s => s.TrackId != null && trackIds.Contains((int)s.TrackId))
             .OrderBy(s => s.Id)
+            .Select(s => s.Id, selector)
             .ToBatchPageAsync(s => (int)s.TrackId!, pagingArguments, cancellationToken);
     }
 }

--- a/code/session-7/GraphQL/Tracks/TrackQueries.cs
+++ b/code/session-7/GraphQL/Tracks/TrackQueries.cs
@@ -1,4 +1,6 @@
 using ConferencePlanner.GraphQL.Data;
+using GreenDonut.Projections;
+using HotChocolate.Execution.Processing;
 using Microsoft.EntityFrameworkCore;
 
 namespace ConferencePlanner.GraphQL.Tracks;
@@ -16,16 +18,18 @@ public static class TrackQueries
     public static async Task<Track?> GetTrackByIdAsync(
         int id,
         ITrackByIdDataLoader trackById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await trackById.LoadAsync(id, cancellationToken);
+        return await trackById.Select(selection).LoadAsync(id, cancellationToken);
     }
 
     public static async Task<IEnumerable<Track>> GetTracksByIdAsync(
         [ID<Track>] int[] ids,
         ITrackByIdDataLoader trackById,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
-        return await trackById.LoadRequiredAsync(ids, cancellationToken);
+        return await trackById.Select(selection).LoadRequiredAsync(ids, cancellationToken);
     }
 }

--- a/code/session-7/GraphQL/Tracks/TrackType.cs
+++ b/code/session-7/GraphQL/Tracks/TrackType.cs
@@ -14,6 +14,7 @@ public static partial class TrackType
     {
         descriptor
             .Field(t => t.Name)
+            .ParentRequires(nameof(Track.Name))
             .UseUpperCase();
     }
 

--- a/code/session-7/GraphQL/Tracks/TrackType.cs
+++ b/code/session-7/GraphQL/Tracks/TrackType.cs
@@ -1,6 +1,7 @@
 using ConferencePlanner.GraphQL.Data;
 using ConferencePlanner.GraphQL.Extensions;
 using GreenDonut.Projections;
+using HotChocolate.Execution.Processing;
 using HotChocolate.Pagination;
 using HotChocolate.Types.Pagination;
 
@@ -21,10 +22,12 @@ public static partial class TrackType
         [Parent] Track track,
         ISessionsByTrackIdDataLoader sessionsByTrackId,
         PagingArguments pagingArguments,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
         return await sessionsByTrackId
             .WithPagingArguments(pagingArguments)
+            .Select(selection)
             .LoadAsync(track.Id, cancellationToken)
             .ToConnectionAsync();
     }

--- a/docs/4-understanding-middleware.md
+++ b/docs/4-understanding-middleware.md
@@ -88,9 +88,12 @@ After `next` has finished executing, the middleware checks if the result is a `s
     {
         descriptor
             .Field(t => t.Name)
+            .ParentRequires(nameof(Track.Name))
             .UseUpperCase();
     }
     ```
+
+    Note: When we apply middleware to a field, it becomes asynchronous, and will not be projected by default. To enable projection of this field, we use the `ParentRequires` method to indicate that the `Name` property of the parent type `Track` is required.
 
 1. Start your server and query your tracks:
 

--- a/docs/5-adding-complex-filter-capabilities.md
+++ b/docs/5-adding-complex-filter-capabilities.md
@@ -176,7 +176,7 @@ Let's start by implementing the 2nd Relay server specification by adding Relay-c
             .AsNoTracking()
             .Where(s => s.TrackId != null && trackIds.Contains((int)s.TrackId))
             .OrderBy(s => s.Id)
-            .Select(s => s.Id, selector)
+            .Select(s => s.TrackId, selector)
             .ToBatchPageAsync(s => (int)s.TrackId!, pagingArguments, cancellationToken);
     }
     ```

--- a/docs/5-adding-complex-filter-capabilities.md
+++ b/docs/5-adding-complex-filter-capabilities.md
@@ -142,18 +142,19 @@ Let's start by implementing the 2nd Relay server specification by adding Relay-c
         [Parent] Track track,
         ISessionsByTrackIdDataLoader sessionsByTrackId,
         PagingArguments pagingArguments,
+        ISelection selection,
         CancellationToken cancellationToken)
     {
         return await sessionsByTrackId
             .WithPagingArguments(pagingArguments)
+            .Select(selection)
             .LoadAsync(track.Id, cancellationToken)
             .ToConnectionAsync();
     }
     ```
 
     ```diff
-      using ConferencePlanner.GraphQL.Extensions;
-    + using GreenDonut.Projections;
+      using HotChocolate.Execution.Processing;
     + using HotChocolate.Pagination;
     + using HotChocolate.Types.Pagination;
     ```
@@ -167,6 +168,7 @@ Let's start by implementing the 2nd Relay server specification by adding Relay-c
     public static async Task<IReadOnlyDictionary<int, Page<Session>>> SessionsByTrackIdAsync(
         IReadOnlyList<int> trackIds,
         ApplicationDbContext dbContext,
+        ISelectorBuilder selector,
         PagingArguments pagingArguments,
         CancellationToken cancellationToken)
     {
@@ -174,12 +176,13 @@ Let's start by implementing the 2nd Relay server specification by adding Relay-c
             .AsNoTracking()
             .Where(s => s.TrackId != null && trackIds.Contains((int)s.TrackId))
             .OrderBy(s => s.Id)
+            .Select(s => s.Id, selector)
             .ToBatchPageAsync(s => (int)s.TrackId!, pagingArguments, cancellationToken);
     }
     ```
 
     ```diff
-      using ConferencePlanner.GraphQL.Data;
+      using GreenDonut.Projections;
     + using HotChocolate.Pagination;
     ```
 

--- a/docs/6-subscriptions.md
+++ b/docs/6-subscriptions.md
@@ -21,6 +21,8 @@ Before we can start with introducing our new subscriptions, we need to first bri
 
     ```csharp
     using ConferencePlanner.GraphQL.Data;
+    using GreenDonut.Projections;
+    using HotChocolate.Execution.Processing;
     using Microsoft.EntityFrameworkCore;
 
     namespace ConferencePlanner.GraphQL.Attendees;
@@ -38,17 +40,19 @@ Before we can start with introducing our new subscriptions, we need to first bri
         public static async Task<Attendee?> GetAttendeeByIdAsync(
             int id,
             IAttendeeByIdDataLoader attendeeById,
+            ISelection selection,
             CancellationToken cancellationToken)
         {
-            return await attendeeById.LoadAsync(id, cancellationToken);
+            return await attendeeById.Select(selection).LoadAsync(id, cancellationToken);
         }
 
         public static async Task<IEnumerable<Attendee>> GetAttendeesByIdAsync(
             [ID<Attendee>] int[] ids,
             IAttendeeByIdDataLoader attendeeById,
+            ISelection selection,
             CancellationToken cancellationToken)
         {
-            return await attendeeById.LoadRequiredAsync(ids, cancellationToken);
+            return await attendeeById.Select(selection).LoadRequiredAsync(ids, cancellationToken);
         }
     }
     ```


### PR DESCRIPTION
Closes #91.

---

There are two issues that I know of:

1. The following query doesn't seem to select the Track `name` field:

    ```graphql
    query one {
      speakers(first: 10) {
        edges {
          node {
            sessions {
              track {
                id
                name
              }
            }
          }
        }
      }
    }
    ```

2. The following query fails with a "could not be translated" error:

    ```graphql
    query two {
      tracks(first: 10) {
        edges {
          node {
            sessions(first: 10) {
              edges {
                node {
                  abstract
                }
              }
            }
          }
        }
      }
    }
    ```